### PR TITLE
add support for loading multiple traces in archive mode

### DIFF
--- a/src/org/traccar/web/client/Application.java
+++ b/src/org/traccar/web/client/Application.java
@@ -63,7 +63,8 @@ public class Application {
         deviceController.getDeviceStore().addStoreHandlers(deviceStoreHandler);
         stateController = new StateController();
         mapController = new MapController(mapHandler);
-        archiveController = new ArchiveController(archiveHanlder, deviceController.getDeviceStore());
+        archiveController = new ArchiveController(archiveHanlder, deviceController.getDeviceStore(),
+                                                  mapController);
         archiveController.getPositionStore().addStoreHandlers(archiveStoreHandler);
 
         view = new ApplicationView(

--- a/src/org/traccar/web/client/controller/ArchiveController.java
+++ b/src/org/traccar/web/client/controller/ArchiveController.java
@@ -42,8 +42,12 @@ public class ArchiveController implements ContentController, ArchiveView.Archive
 
     private ArchiveView archiveView;
 
-    public ArchiveController(ArchiveHandler archiveHandler, ListStore<Device> deviceStore) {
+    private MapController mapController;
+
+    public ArchiveController(ArchiveHandler archiveHandler, ListStore<Device> deviceStore,
+                             MapController mapController) {
         this.archiveHandler = archiveHandler;
+        this.mapController = mapController;
         PositionProperties positionProperties = GWT.create(PositionProperties.class);
         positionStore = new ListStore<Position>(positionProperties.id());
         archiveView = new ArchiveView(this, positionStore, deviceStore);
@@ -89,6 +93,7 @@ public class ArchiveController implements ContentController, ArchiveView.Archive
     @Override
     public void onClear() {
         positionStore.clear();
+        mapController.clearArchivePositions();
     }
 
     public void selectPosition(Position position) {

--- a/src/org/traccar/web/client/controller/MapController.java
+++ b/src/org/traccar/web/client/controller/MapController.java
@@ -105,6 +105,10 @@ public class MapController implements ContentController, MapView.MapHandler {
         mapView.showArchivePositions(sortedPositions);
     }
 
+    public void clearArchivePositions() {
+        mapView.clearArchivePositions();
+    }
+
     public void selectArchivePosition(Position position) {
         mapView.selectArchivePosition(position);
     }

--- a/src/org/traccar/web/client/view/MapView.java
+++ b/src/org/traccar/web/client/view/MapView.java
@@ -165,8 +165,10 @@ public class MapView {
             }
         });
 
-        latestPositionRenderer = new MapPositionRenderer(this, MarkerIconFactory.IconType.iconLatest, latestPositionSelectHandler);
-        archivePositionRenderer = new MapPositionRenderer(this, MarkerIconFactory.IconType.iconArchive, archivePositionSelectHandler);
+        latestPositionRenderer = new MapPositionRenderer(this, MarkerIconFactory.IconType.iconLatest,
+                                                         latestPositionSelectHandler, false /* appendMode */);
+        archivePositionRenderer = new MapPositionRenderer(this, MarkerIconFactory.IconType.iconArchive,
+                                                          archivePositionSelectHandler, true /* appendMode */);
     }
 
     private final MapPositionRenderer latestPositionRenderer;
@@ -180,6 +182,10 @@ public class MapView {
     public void showArchivePositions(List<Position> positions) {
         archivePositionRenderer.showTrack(positions);
         archivePositionRenderer.showPositions(positions);
+    }
+
+    public void clearArchivePositions() {
+        archivePositionRenderer.clear();
     }
 
     public void selectDevice(Device device) {


### PR DESCRIPTION
Now the load button in archive mode does not erase the previous
trace. The new trace is drawn with another color to help differentiate
several traces. The clear button erases all the traces.