### PR TITLE
Always show geofences on the Map

### DIFF
--- a/web/app/Style.js
+++ b/web/app/Style.js
@@ -68,6 +68,7 @@ Ext.define('Traccar.Style', {
     mapMaxZoom: 19,
     mapDelay: 500,
 
+    mapGeofenceTextColor: 'rgba(14, 88, 141, 1.0)',
     mapGeofenceColor: 'rgba(21, 127, 204, 1.0)',
     mapGeofenceOverlay: 'rgba(21, 127, 204, 0.2)',
     mapGeofenceWidth: 5,

--- a/web/app/view/Map.js
+++ b/web/app/view/Map.js
@@ -39,8 +39,17 @@ Ext.define('Traccar.view.Map', {
         return this.reportSource;
     },
 
+    getGeofencesSource: function () {
+        return this.geofencesSource;
+    },
+
     initMap: function () {
         this.callParent();
+
+        this.geofencesSource = new ol.source.Vector({});
+        this.map.addLayer(new ol.layer.Vector({
+            source: this.geofencesSource
+        }));
 
         this.latestSource = new ol.source.Vector({});
         this.map.addLayer(new ol.layer.Vector({

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -69,15 +69,15 @@ Ext.define('Traccar.view.MapController', {
             xtype: 'header',
             title: Strings.mapTitle,
             items: [{
-                    xtype: 'button',
-                    handler: 'showGeofences',
-                    reference: 'showGeofencesButton',
-                    glyph: 'xf21d@FontAwesome',
-                    enableToggle: true,
-                    pressed: true,
-                    tooltip: Strings.sharedGeofences,
-                    tooltipType: 'title'
-                }]
+                xtype: 'button',
+                handler: 'showGeofences',
+                reference: 'showGeofencesButton',
+                glyph: 'xf21d@FontAwesome',
+                enableToggle: true,
+                pressed: true,
+                tooltip: Strings.sharedGeofences,
+                tooltipType: 'title'
+            }]
         };
     },
 
@@ -353,15 +353,8 @@ Ext.define('Traccar.view.MapController', {
                     color: Traccar.Style.mapGeofenceColor,
                     width: Traccar.Style.mapGeofenceWidth
                 }),
-                image: new ol.style.Circle({
-                    radius: Traccar.Style.mapGeofenceRadius,
-                    fill: new ol.style.Fill({
-                        color: Traccar.Style.mapGeofenceColor
-                    })
-                }),
                 text: new ol.style.Text({
                     text: label,
-                    textBaseline: 'bottom',
                     fill: new ol.style.Fill({
                         color: Traccar.Style.mapGeofenceTextColor
                     }),
@@ -377,7 +370,8 @@ Ext.define('Traccar.view.MapController', {
     showGeofences: function () {
         if (this.lookupReference('showGeofencesButton').pressed) {
             Ext.getStore('Geofences').each(function (geofence) {
-                var feature = new ol.Feature(Traccar.GeofenceConverter.wktToGeometry(this.getView().getMapView(), geofence.get('area')));
+                var feature = new ol.Feature(Traccar.GeofenceConverter
+                        .wktToGeometry(this.getView().getMapView(), geofence.get('area')));
                 feature.setStyle(this.getGeofenceStyle(geofence.get('name')));
                 this.getView().getGeofencesSource().addFeature(feature);
                 return true;


### PR DESCRIPTION
Geofences are showed by default.

There is strange bug, if I set header in a view config - I get error `header.hide is not a function` If set it manually it is OK. In `State` panel it works OK. Weird.

Button looks alone, but when we move settings there, hope it won't looks so.
Just clear and show again on any geofences updates. Don't think we need spend time on precise synchronizing features and store.

![image](https://cloud.githubusercontent.com/assets/5688080/19267910/dec00b9a-8fca-11e6-9413-be81efdef682.png)
