### PR TITLE
Implement live routes

### DIFF
--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -106,6 +106,14 @@ Ext.define('Traccar.Application', {
         }
     },
 
+    getAttributePreference: function (key, defaultValue) {
+        if (this.getServer().get('forceSettings')) {
+            return this.getServer().get('attributes')[key] || this.getUser().get('attributes')[key] || defaultValue;
+        } else {
+            return this.getUser().get('attributes')[key] || this.getServer().get('attributes')[key] || defaultValue;
+        }
+    },
+
     showError: function (response) {
         var data;
         if (Ext.isString(response)) {

--- a/web/app/Style.js
+++ b/web/app/Style.js
@@ -77,5 +77,7 @@ Ext.define('Traccar.Style', {
     coordinatePrecision: 6,
     numberPrecision: 2,
 
-    reportTagfieldWidth: 375
+    reportTagfieldWidth: 375,
+
+    headerButtonsMargin: '0 5'
 });

--- a/web/app/view/Map.js
+++ b/web/app/view/Map.js
@@ -43,6 +43,14 @@ Ext.define('Traccar.view.Map', {
         return this.geofencesSource;
     },
 
+    getLiveRouteSource: function () {
+        return this.liveRouteSource;
+    },
+
+    getLiveRouteLayer: function () {
+        return this.liveRouteLayer;
+    },
+
     initMap: function () {
         this.callParent();
 
@@ -50,6 +58,13 @@ Ext.define('Traccar.view.Map', {
         this.map.addLayer(new ol.layer.Vector({
             source: this.geofencesSource
         }));
+
+        this.liveRouteSource = new ol.source.Vector({});
+        this.liveRouteLayer = new ol.layer.Vector({
+            source: this.liveRouteSource,
+            visible: false
+        });
+        this.map.addLayer(this.liveRouteLayer);
 
         this.latestSource = new ol.source.Vector({});
         this.map.addLayer(new ol.layer.Vector({

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -215,7 +215,7 @@ Ext.define('Traccar.view.MapController', {
                     ])
                 ])
             });
-            liveLine.setStyle(this.getRouteStyle(position.get('deviceId')));
+            liveLine.setStyle(this.getRouteStyle(deviceId));
             this.liveRoutes[deviceId] = liveLine;
             this.getView().getLiveRouteSource().addFeature(liveLine);
         }

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -105,6 +105,7 @@
     "mapBingAerial": "Bing Maps Aerial",
     "mapShapePolygon": "Polygon",
     "mapShapeCircle": "Circle",
+    "mapLiveRoutes": "Live Routes",
     "stateTitle": "State",
     "stateName": "Attribute",
     "stateValue": "Value",


### PR DESCRIPTION
- Live routes are drawn always, the button just toggles layer visibility
- Tails length can be configured via `web.liveRouteLength` server or user attribute.
- Added wrapper `getAttributePreference` to use it in future

![image](https://cloud.githubusercontent.com/assets/5688080/19755817/b70a16d6-9c31-11e6-8c99-658a2a9fc512.png)
