### PR TITLE
Fix close geofence geometry edit window after cancel click.

### DIFF
--- a/web/app/view/GeofenceMap.js
+++ b/web/app/view/GeofenceMap.js
@@ -50,7 +50,7 @@ Ext.define('Traccar.view.GeofenceMap', {
             tooltip: Strings.sharedCancel,
             tooltipType: 'title',
             minWidth: 0,
-            handler: 'closeView'
+            handler: 'onCancelClick'
         }]
     },
 


### PR DESCRIPTION
Geofence geometry edit window do not close on Cancel click.