### PR TITLE
Fix icon blinking

### DIFF
--- a/web/app/DeviceImages.js
+++ b/web/app/DeviceImages.js
@@ -73,6 +73,7 @@ Ext.define('Traccar.DeviceImages', {
             imgSize: [width, height],
             src: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(new XMLSerializer().serializeToString(svg.documentElement))
         });
+        image.load();
         image.fill = color;
         image.zoom = zoom;
         image.angle = angle;

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -98,7 +98,7 @@ Ext.define('Traccar.view.MapController', {
     },
 
     updateDevice: function (store, data) {
-        var i, device, deviceId, marker;
+        var i, device, deviceId, marker, style;
 
         if (!Ext.isArray(data)) {
             data = [data];
@@ -110,8 +110,12 @@ Ext.define('Traccar.view.MapController', {
 
             if (deviceId in this.latestMarkers) {
                 marker = this.latestMarkers[deviceId];
-                marker.setStyle(
-                    this.changeMarkerColor(marker.getStyle(), this.getDeviceColor(device), device.get('category')));
+                style = marker.getStyle();
+                if (style.getImage().fill !== this.getDeviceColor(device) ||
+                        style.getImage().category !== device.get('category')) {
+                    marker.setStyle(
+                        this.changeMarkerColor(style, this.getDeviceColor(device), device.get('category')));
+                }
             }
         }
     },
@@ -151,8 +155,11 @@ Ext.define('Traccar.view.MapController', {
         deviceId = position.get('deviceId');
         if (deviceId in this.latestMarkers) {
             marker = this.latestMarkers[deviceId];
+            style = marker.getStyle();
+            if (style.getImage().angle !== position.get('course')) {
+                marker.setStyle(this.rotateMarker(marker.getStyle(), position.get('course')));
+            }
             marker.setGeometry(geometry);
-            marker.setStyle(this.rotateMarker(marker.getStyle(), position.get('course')));
         } else {
             marker = new ol.Feature(geometry);
             marker.set('record', device);


### PR DESCRIPTION
Hope I've fixed it. Please check.

Key changes:
- `image.load()` just in case, load image as soon as possible.
- Added checks to avoid blank/double style updates

I think significant change was moving `marker.setGeometry(geometry);` after `marker.setStyle()`

Surprising fact that it did not blink in IE.
