### PR TITLE
Remove marker style recreation on marker rotate and color change

### DIFF
--- a/web/app/DeviceImages.js
+++ b/web/app/DeviceImages.js
@@ -62,6 +62,11 @@ Ext.define('Traccar.DeviceImages', {
         return svg;
     },
 
+    formatSrc: function (svg) {
+        return 'data:image/svg+xml;charset=utf-8,' +
+                encodeURIComponent(new XMLSerializer().serializeToString(svg.documentElement));
+    },
+
     getImageIcon: function (color, zoom, angle, category) {
         var image, svg, width, height;
 
@@ -71,14 +76,26 @@ Ext.define('Traccar.DeviceImages', {
 
         image =  new ol.style.Icon({
             imgSize: [width, height],
-            src: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(new XMLSerializer().serializeToString(svg.documentElement))
+            src: this.formatSrc(svg)
         });
-        image.load();
         image.fill = color;
         image.zoom = zoom;
         image.angle = angle;
         image.category = category;
 
         return image;
+    },
+
+    rotateImageIcon: function (image, angle) {
+        var svg = Traccar.DeviceImages.getImageSvg(image.fill, image.zoom, angle, image.category);
+        image.getImage().src = this.formatSrc(svg);
+        image.angle = angle;
+    },
+
+    changeImageColor: function (image, color, category) {
+        var svg = Traccar.DeviceImages.getImageSvg(color, image.zoom, image.angle, category);
+        image.getImage().src = this.formatSrc(svg);
+        image.fill = color;
+        image.category = category;
     }
 });

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -86,17 +86,6 @@ Ext.define('Traccar.view.MapController', {
         }
     },
 
-    changeMarkerColor: function (style, color, category) {
-        var newStyle = new ol.style.Style({
-            image: Traccar.DeviceImages.getImageIcon(color,
-                    style.getImage().zoom,
-                    style.getImage().angle,
-                    category),
-            text: style.getText()
-        });
-        return newStyle;
-    },
-
     updateDevice: function (store, data) {
         var i, device, deviceId, marker, style;
 
@@ -113,8 +102,9 @@ Ext.define('Traccar.view.MapController', {
                 style = marker.getStyle();
                 if (style.getImage().fill !== this.getDeviceColor(device) ||
                         style.getImage().category !== device.get('category')) {
-                    marker.setStyle(
-                        this.changeMarkerColor(style, this.getDeviceColor(device), device.get('category')));
+                    Traccar.DeviceImages.changeImageColor(style.getImage(),
+                            this.getDeviceColor(device), device.get('category'));
+                    marker.changed();
                 }
             }
         }
@@ -157,7 +147,7 @@ Ext.define('Traccar.view.MapController', {
             marker = this.latestMarkers[deviceId];
             style = marker.getStyle();
             if (style.getImage().angle !== position.get('course')) {
-                marker.setStyle(this.rotateMarker(marker.getStyle(), position.get('course')));
+                Traccar.DeviceImages.rotateImageIcon(style.getImage(), position.get('course'));
             }
             marker.setGeometry(geometry);
         } else {
@@ -327,17 +317,6 @@ Ext.define('Traccar.view.MapController', {
             image: image,
             text: text
         });
-    },
-
-    rotateMarker: function (style, angle) {
-        var newStyle = new ol.style.Style({
-            image: Traccar.DeviceImages.getImageIcon(style.getImage().fill,
-                    style.getImage().zoom,
-                    angle,
-                    style.getImage().category),
-            text: style.getText()
-        });
-        return newStyle;
     },
 
     selectMarker: function (marker, center) {


### PR DESCRIPTION
Here is another try of fixing flickering, hope it is last.

Here we do not create new style on every update, just updating `src` of inner `<img>` object. After `setGeometry` browser draws new image.

Also do the same then updating device, but we have to call `changed()` to re-render image, otherwise it will be updated in a few seconds.

Moved this functions to `DeviceImages` because it is better place and to unload `MapController` a bit