### PR TITLE
Totally update device marker instead of updating only image src

### DIFF
--- a/web/app/DeviceImages.js
+++ b/web/app/DeviceImages.js
@@ -98,15 +98,8 @@ Ext.define('Traccar.DeviceImages', {
     },
 
     rotateImageIcon: function (image, angle) {
-        var svg = Traccar.DeviceImages.getImageSvg(image.fill, image.zoom, angle, image.category);
+        var svg = this.getImageSvg(image.fill, image.zoom, angle, image.category);
         image.getImage().src = this.formatSrc(svg);
         image.angle = angle;
-    },
-
-    changeImageColor: function (image, color, category) {
-        var svg = Traccar.DeviceImages.getImageSvg(color, image.zoom, image.angle, category);
-        image.getImage().src = this.formatSrc(svg);
-        image.fill = color;
-        image.category = category;
     }
 });

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -103,9 +103,7 @@ Ext.define('Traccar.view.MapController', {
                 style = marker.getStyle();
                 if (style.getImage().fill !== this.getDeviceColor(device) ||
                         style.getImage().category !== device.get('category')) {
-                    Traccar.DeviceImages.changeImageColor(style.getImage(),
-                            this.getDeviceColor(device), device.get('category'));
-                    marker.changed();
+                    marker.setStyle(this.updateDeviceMarker(style, this.getDeviceColor(device), device.get('category')));
                 }
                 if (style.getText().getText() !== device.get('name')) {
                     style.getText().setText(device.get('name'));
@@ -331,6 +329,20 @@ Ext.define('Traccar.view.MapController', {
                 zoom,
                 style.getImage().angle,
                 style.getImage().category);
+        text = style.getText();
+        text.setOffsetY(-image.getSize()[1] / 2 - Traccar.Style.mapTextOffset);
+        return new ol.style.Style({
+            image: image,
+            text: text
+        });
+    },
+
+    updateDeviceMarker: function (style, color, category) {
+        var image, text;
+        image = Traccar.DeviceImages.getImageIcon(color,
+                style.getImage().zoom,
+                style.getImage().angle,
+                category);
         text = style.getText();
         text.setOffsetY(-image.getSize()[1] / 2 - Traccar.Style.mapTextOffset);
         return new ol.style.Style({


### PR DESCRIPTION
fix #335 

The main problem that `ol.style.Icon` does not have necessary setters to correctly set `src` and `size`.
Therefore changing all other icon to arrow or arrow to all other will cause visual bug like not centered or what is worse
![image](https://cloud.githubusercontent.com/assets/5688080/20638837/98d2330e-b3e4-11e6-8a16-d6c2f0f8b759.png)

To fix it, I have to adjust some private fields of `ol.style.Icon` that is prohibited by our style requirements.
Because of that I reverted total style recreation on device update.

PS: may be we have to spend some time to contribute necessary setters to openlayers, it is welcomed https://github.com/openlayers/ol3/issues/3137#issuecomment-241994282

