### PR TITLE
Show events on map

### DIFF
--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -202,24 +202,26 @@ Ext.define('Traccar.view.MapMarkerController', {
 
         this.addReportMarkers(store, data);
 
-        this.reportRoute = [];
-        for (i = 0; i < data.length; i++) {
-            position = data[i];
-            point = ol.proj.fromLonLat([
-                position.get('longitude'),
-                position.get('latitude')
-            ]);
-            if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
-                this.reportRoute.push(new ol.Feature({
-                    geometry: new ol.geom.LineString([])
-                }));
-                this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
-                this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
+        if (data.length > 0) {
+            this.reportRoute = [];
+            for (i = 0; i < data.length; i++) {
+                position = data[i];
+                point = ol.proj.fromLonLat([
+                    position.get('longitude'),
+                    position.get('latitude')
+                ]);
+                if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
+                    this.reportRoute.push(new ol.Feature({
+                        geometry: new ol.geom.LineString([])
+                    }));
+                    this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
+                    this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
+                }
+                this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
             }
-            this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
-        }
 
-        this.getView().getMapView().fit(this.reportRoute[0].getGeometry(), this.getView().getMap().getSize());
+            this.getView().getMapView().fit(this.reportRoute[0].getGeometry(), this.getView().getMap().getSize());
+        }
     },
 
     addReportMarkers: function (store, data) {

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -202,48 +202,44 @@ Ext.define('Traccar.view.MapMarkerController', {
 
         this.addReportMarkers(store, data);
 
-        if (data.length > 0) {
-            this.reportRoute = [];
-            for (i = 0; i < data.length; i++) {
-                position = data[i];
-                point = ol.proj.fromLonLat([
-                    position.get('longitude'),
-                    position.get('latitude')
-                ]);
-                if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
-                    this.reportRoute.push(new ol.Feature({
-                        geometry: new ol.geom.LineString([])
-                    }));
-                    this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
-                    this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
-                }
-                this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
+        this.reportRoute = [];
+        for (i = 0; i < data.length; i++) {
+            position = data[i];
+            point = ol.proj.fromLonLat([
+                position.get('longitude'),
+                position.get('latitude')
+            ]);
+            if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
+                this.reportRoute.push(new ol.Feature({
+                    geometry: new ol.geom.LineString([])
+                }));
+                this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
+                this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
             }
-
-            this.getView().getMapView().fit(this.reportRoute[0].getGeometry(), this.getView().getMap().getSize());
+            this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
         }
+
+        this.getView().getMapView().fit(this.reportRoute[0].getGeometry(), this.getView().getMap().getSize());
     },
 
     addReportMarkers: function (store, data) {
         var i, position, point, geometry, marker, style;
         this.clearReport();
-        if (data.length > 0) {
-            for (i = 0; i < data.length; i++) {
-                position = data[i];
-                point = ol.proj.fromLonLat([
-                    position.get('longitude'),
-                    position.get('latitude')
-                ]);
-                geometry = new ol.geom.Point(point);
-                marker = new ol.Feature(geometry);
-                marker.set('record', position);
-                style = this.getReportMarker(position.get('deviceId'), position.get('course'));
-                /*style.getText().setText(
-                    Ext.Date.format(position.get('fixTime'), Traccar.Style.dateTimeFormat24));*/
-                marker.setStyle(style);
-                this.reportMarkers[position.get('id')] = marker;
-                this.getView().getReportSource().addFeature(marker);
-            }
+        for (i = 0; i < data.length; i++) {
+            position = data[i];
+            point = ol.proj.fromLonLat([
+                position.get('longitude'),
+                position.get('latitude')
+            ]);
+            geometry = new ol.geom.Point(point);
+            marker = new ol.Feature(geometry);
+            marker.set('record', position);
+            style = this.getReportMarker(position.get('deviceId'), position.get('course'));
+            /*style.getText().setText(
+                Ext.Date.format(position.get('fixTime'), Traccar.Style.dateTimeFormat24));*/
+            marker.setStyle(style);
+            this.reportMarkers[position.get('id')] = marker;
+            this.getView().getReportSource().addFeature(marker);
         }
     },
 

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -197,12 +197,10 @@ Ext.define('Traccar.view.ReportController', {
     loadEvents: function (store, data) {
         var i, eventObject, positionIds = [];
         Ext.getStore('ReportRoute').removeAll();
-        if (data.length > 0) {
-            for (i = 0; i < data.length; i++) {
-                eventObject = data[i];
-                if (eventObject.get('positionId')) {
-                    positionIds.push(eventObject.get('positionId'));
-                }
+        for (i = 0; i < data.length; i++) {
+            eventObject = data[i];
+            if (eventObject.get('positionId')) {
+                positionIds.push(eventObject.get('positionId'));
             }
         }
         if (positionIds.length > 0) {

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -195,20 +195,20 @@ Ext.define('Traccar.view.ReportController', {
     },
 
     loadEvents: function (store, data) {
-        var i, eventObject, positionIds = {};
+        var i, eventObject, positionIds = [];
         Ext.getStore('ReportRoute').removeAll();
         if (data.length > 0) {
             for (i = 0; i < data.length; i++) {
                 eventObject = data[i];
                 if (eventObject.get('positionId')) {
-                    positionIds[eventObject.get('positionId')] = true;
+                    positionIds.push(eventObject.get('positionId'));
                 }
             }
         }
-        if (Object.keys(positionIds).length > 0) {
+        if (positionIds.length > 0) {
             Ext.getStore('Positions').load({
                 params: {
-                    positionId: Object.keys(positionIds)
+                    id: positionIds
                 },
                 callback: function (records, operation, success) {
                     if (success) {

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -37,6 +37,11 @@ Ext.define('Traccar.view.ReportController', {
                 'map': {
                     selectreport: 'selectReport'
                 }
+            },
+            store: {
+                '#ReportEvents': {
+                    load: 'loadEvents'
+                }
             }
         }
     },
@@ -126,7 +131,7 @@ Ext.define('Traccar.view.ReportController', {
 
     clearReport: function (reportType) {
         this.getView().getStore().removeAll();
-        if (reportType === 'trips') {
+        if (reportType === 'trips' || reportType === 'events') {
             Ext.getStore('ReportRoute').removeAll();
         }
     },
@@ -139,6 +144,9 @@ Ext.define('Traccar.view.ReportController', {
             if (report instanceof Traccar.model.ReportTrip) {
                 this.selectTrip(report);
             }
+            if (report instanceof Traccar.model.Event) {
+                this.selectEvent(report);
+            }
         }
     },
 
@@ -149,10 +157,16 @@ Ext.define('Traccar.view.ReportController', {
     },
 
     selectReport: function (object, center) {
-        var reportType = this.lookupReference('reportTypeField').getValue();
-        if (object instanceof Traccar.model.Position && reportType === 'route') {
-            this.getView().getSelectionModel().select([object], false, true);
-            this.getView().getView().focusRow(object);
+        var positionEvent, reportType = this.lookupReference('reportTypeField').getValue();
+        if (object instanceof Traccar.model.Position) {
+            if (reportType === 'route') {
+                this.getView().getSelectionModel().select([object], false, true);
+                this.getView().getView().focusRow(object);
+            } else if (reportType === 'events') {
+                positionEvent = this.getView().getStore().findRecord('positionId', object.get('id'), 0, false, true, true);
+                this.getView().getSelectionModel().select([positionEvent], false, true);
+                this.getView().getView().focusRow(positionEvent);
+            }
         }
     },
 
@@ -168,6 +182,41 @@ Ext.define('Traccar.view.ReportController', {
                 to: to.toISOString()
             }
         });
+    },
+
+    selectEvent: function (event) {
+        var position;
+        if (event.get('positionId')) {
+            position = Ext.getStore('ReportRoute').getById(event.get('positionId'));
+            if (position) {
+                this.fireEvent('selectreport', position, true);
+            }
+        }
+    },
+
+    loadEvents: function (store, data) {
+        var i, eventObject, positionIds = {};
+        Ext.getStore('ReportRoute').removeAll();
+        if (data.length > 0) {
+            for (i = 0; i < data.length; i++) {
+                eventObject = data[i];
+                if (eventObject.get('positionId')) {
+                    positionIds[eventObject.get('positionId')] = true;
+                }
+            }
+        }
+        if (Object.keys(positionIds).length > 0) {
+            Ext.getStore('Positions').load({
+                params: {
+                    positionId: Object.keys(positionIds)
+                },
+                callback: function (records, operation, success) {
+                    if (success) {
+                        Ext.getStore('ReportRoute').add(records);
+                    }
+                }
+            });
+        }
     },
 
     downloadFile: function (requestUrl, requestParams) {


### PR DESCRIPTION
Key changes:

- Request positions to "Positions" store and add them to "ReportRoute" then. I think it is more natural to request positions from `api/positions` not from `api/report`
- Split `loadReport` on two functions. One draws route line, other draws markers. The only thing we iterate `data` twice in case routes.
- Handle bidirectional selecting. Select marker on map highlight event in grid and backward.

- in `loadEvents` function I used object instead of array to remove duplicate ids. It is not very frequent case, but there can be few events connected to one position. Just not to request them twice.

![image](https://cloud.githubusercontent.com/assets/5688080/20740700/0616eefa-b6e7-11e6-9d43-1657705674bf.png)
