### PR TITLE
Add Test Mail button to Account dialog.

### DIFF
--- a/web/app/view/SettingsMenuController.js
+++ b/web/app/view/SettingsMenuController.js
@@ -53,6 +53,7 @@ Ext.define('Traccar.view.SettingsMenuController', {
     onUserClick: function () {
         var dialog = Ext.create('Traccar.view.UserDialog');
         dialog.down('form').loadRecord(Traccar.app.getUser());
+        dialog.lookupReference('testMailButton').setHidden(false);
         dialog.show();
     },
 

--- a/web/app/view/UserDialog.js
+++ b/web/app/view/UserDialog.js
@@ -155,6 +155,14 @@ Ext.define('Traccar.view.UserDialog', {
         tooltip: Strings.sharedGetMapState,
         tooltipType: 'title'
     }, {
+        glyph: 'xf003@FontAwesome',
+        minWidth: 0,
+        handler: 'testMail',
+        hidden: true,
+        reference: 'testMailButton',
+        tooltip: Strings.sharedTestMail,
+        tooltipType: 'title'
+    }, {
         xtype: 'tbfill'
     }, {
         glyph: 'xf00c@FontAwesome',

--- a/web/app/view/UserDialogController.js
+++ b/web/app/view/UserDialogController.js
@@ -42,6 +42,16 @@ Ext.define('Traccar.view.UserDialogController', {
         this.lookupReference('tokenField').setValue(newToken);
     },
 
+    testMail: function () {
+        Ext.Ajax.request({
+            url: 'api/users/notifications/test',
+            method: 'POST',
+            failure: function (response) {
+                Traccar.app.showError(response);
+            }
+        });
+    },
+
     onSaveClick: function (button) {
         var dialog, record, store;
         dialog = button.up('window').down('form');

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -40,6 +40,7 @@
     "sharedAlias": "Alias",
     "sharedDeviceDistance": "Device Distance",
     "sharedDevice": "Device",
+    "sharedTestMail": "Send Test Email",
     "errorTitle": "Error",
     "errorUnknown": "Unknown error",
     "errorConnection": "Connection error",


### PR DESCRIPTION
Added button to Account dialog only.
It may confuse admins if enable for all users dialog.
They may think it sends test email to other user.

![image](https://cloud.githubusercontent.com/assets/5688080/20750440/b66a1c2e-b718-11e6-8825-0fcb2b8787a7.png)
