### PR TITLE
Handle eventId url parameter

### DIFF
--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -141,13 +141,5 @@ Ext.define('Traccar.Application', {
         } else {
             Ext.Msg.alert(Strings.errorTitle, Strings.errorConnection);
         }
-    },
-
-    removeUrlParameter: function (param) {
-        var params = Ext.Object.fromQueryString(window.location.search);
-        delete params[param];
-        window.history.pushState(null, null, window.location.pathname + '?' + Ext.Object.toQueryString(params));
-    },
-
-    hasEventId: false
+    }
 });

--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -141,5 +141,13 @@ Ext.define('Traccar.Application', {
         } else {
             Ext.Msg.alert(Strings.errorTitle, Strings.errorConnection);
         }
-    }
+    },
+
+    removeUrlParameter: function (param) {
+        var params = Ext.Object.fromQueryString(window.location.search);
+        delete params[param];
+        window.history.pushState(null, null, window.location.pathname + '?' + Ext.Object.toQueryString(params));
+    },
+
+    hasEventId: false
 });

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -97,7 +97,7 @@ Ext.define('Traccar.controller.Root', {
         eventId = Ext.Object.fromQueryString(window.location.search).eventId;
         if (eventId) {
             this.fireEvent('showsingleevent', eventId);
-            //this.removeUrlParameter('eventId');
+            this.removeUrlParameter('eventId');
         }
     },
 

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -96,7 +96,7 @@ Ext.define('Traccar.controller.Root', {
         }
         eventId = Ext.Object.fromQueryString(window.location.search).eventId;
         if (eventId) {
-            this.application.fireEvent('showSingleEvent', eventId);
+            this.fireEvent('showsingleevent', eventId);
             //this.removeUrlParameter('eventId');
         }
     },

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -75,7 +75,7 @@ Ext.define('Traccar.controller.Root', {
     },
 
     loadApp: function () {
-        var attribution;
+        var attribution, eventId;
         Ext.getStore('Groups').load();
         Ext.getStore('Geofences').load();
         Ext.getStore('AttributeAliases').load();
@@ -94,6 +94,11 @@ Ext.define('Traccar.controller.Root', {
         } else {
             Ext.create('widget.main');
         }
+        eventId = Ext.Object.fromQueryString(window.location.search).eventId;
+        if (eventId) {
+            this.application.fireEvent('showSingleEvent', eventId);
+            //this.removeUrlParameter('eventId');
+        }
     },
 
     beep: function () {
@@ -106,6 +111,12 @@ Ext.define('Traccar.controller.Root', {
     mutePressed: function () {
         var muteButton = Ext.getCmp('muteButton');
         return muteButton && !muteButton.pressed;
+    },
+
+    removeUrlParameter: function (param) {
+        var params = Ext.Object.fromQueryString(window.location.search);
+        delete params[param];
+        window.history.pushState(null, null, window.location.pathname + '?' + Ext.Object.toQueryString(params));
     },
 
     asyncUpdate: function (first) {

--- a/web/app/store/Positions.js
+++ b/web/app/store/Positions.js
@@ -21,6 +21,9 @@ Ext.define('Traccar.store.Positions', {
 
     proxy: {
         type: 'rest',
-        url: 'api/positions'
+        url: 'api/positions',
+        headers: {
+            'Accept': 'application/json'
+        }
     }
 });

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -31,8 +31,7 @@ Ext.define('Traccar.view.MapMarkerController', {
             controller: {
                 '*': {
                     selectdevice: 'selectDevice',
-                    selectreport: 'selectReport',
-                    showsingleevent: 'showSingleEvent'
+                    selectreport: 'selectReport'
                 }
             },
             store: {
@@ -64,10 +63,6 @@ Ext.define('Traccar.view.MapMarkerController', {
         this.reportMarkers = {};
         this.liveRoutes = {};
         this.liveRouteLength = Traccar.app.getAttributePreference('web.liveRouteLength', 10);
-    },
-
-    showSingleEvent: function () {
-        this.singleEvent = true;
     },
 
     getDeviceColor: function (device) {
@@ -252,10 +247,6 @@ Ext.define('Traccar.view.MapMarkerController', {
             this.getView().getMapView().fit([minx, miny, maxx, maxy], this.getView().getMap().getSize());
         } else if (geometry) {
             this.getView().getMapView().fit(geometry, this.getView().getMap().getSize());
-        }
-        if (this.singleEvent) {
-            this.singleEvent = false;
-            this.fireEvent('selectreport', data[0], false);
         }
     },
 

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -31,7 +31,8 @@ Ext.define('Traccar.view.MapMarkerController', {
             controller: {
                 '*': {
                     selectdevice: 'selectDevice',
-                    selectreport: 'selectReport'
+                    selectreport: 'selectReport',
+                    showsingleevent: 'showSingleEvent'
                 }
             },
             store: {
@@ -63,6 +64,10 @@ Ext.define('Traccar.view.MapMarkerController', {
         this.reportMarkers = {};
         this.liveRoutes = {};
         this.liveRouteLength = Traccar.app.getAttributePreference('web.liveRouteLength', 10);
+    },
+
+    showSingleEvent: function () {
+        this.singleEvent = true;
     },
 
     getDeviceColor: function (device) {
@@ -248,9 +253,9 @@ Ext.define('Traccar.view.MapMarkerController', {
         } else if (geometry) {
             this.getView().getMapView().fit(geometry, this.getView().getMap().getSize());
         }
-        if (Traccar.app.hasEventId) {
+        if (this.singleEvent) {
+            this.singleEvent = false;
             this.fireEvent('selectreport', data[0], false);
-            Traccar.app.hasEventId = false;
         }
     },
 

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -202,25 +202,21 @@ Ext.define('Traccar.view.MapMarkerController', {
 
         this.addReportMarkers(store, data);
 
-        if (data.length > 0) {
-            this.reportRoute = [];
-            for (i = 0; i < data.length; i++) {
-                position = data[i];
-                point = ol.proj.fromLonLat([
-                    position.get('longitude'),
-                    position.get('latitude')
-                ]);
-                if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
-                    this.reportRoute.push(new ol.Feature({
-                        geometry: new ol.geom.LineString([])
-                    }));
-                    this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
-                    this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
-                }
-                this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
+        this.reportRoute = [];
+        for (i = 0; i < data.length; i++) {
+            position = data[i];
+            point = ol.proj.fromLonLat([
+                position.get('longitude'),
+                position.get('latitude')
+            ]);
+            if (i === 0 || data[i].get('deviceId') !== data[i - 1].get('deviceId')) {
+                this.reportRoute.push(new ol.Feature({
+                    geometry: new ol.geom.LineString([])
+                }));
+                this.reportRoute[this.reportRoute.length - 1].setStyle(this.getRouteStyle(data[i].get('deviceId')));
+                this.getView().getRouteSource().addFeature(this.reportRoute[this.reportRoute.length - 1]);
             }
-
-            this.getView().getMapView().fit(this.reportRoute[0].getGeometry(), this.getView().getMap().getSize());
+            this.reportRoute[this.reportRoute.length - 1].getGeometry().appendCoordinate(point);
         }
     },
 

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -229,10 +229,15 @@ Ext.define('Traccar.view.MapMarkerController', {
                 position.get('longitude'),
                 position.get('latitude')
             ]);
-            minx = minx ? Math.min(point[0], minx) : point[0];
-            miny = miny ? Math.min(point[1], miny) : point[1];
-            maxx = maxx ? Math.max(point[0], maxx) : point[0];
-            maxy = maxy ? Math.max(point[1], maxy) : point[1];
+            if (i === 0) {
+                minx = maxx = point[0];
+                miny = maxy = point[1];
+            } else {
+                minx = Math.min(point[0], minx);
+                miny = Math.min(point[1], miny);
+                maxx = Math.max(point[0], maxx);
+                maxy = Math.max(point[1], maxy);
+            }
             geometry = new ol.geom.Point(point);
             marker = new ol.Feature(geometry);
             marker.set('record', position);

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -225,7 +225,7 @@ Ext.define('Traccar.view.MapMarkerController', {
     },
 
     addReportMarkers: function (store, data) {
-        var i, position, point, geometry, marker, style;
+        var i, position, point, geometry, marker, style, minx, miny, maxx, maxy;
         this.clearReport();
         for (i = 0; i < data.length; i++) {
             position = data[i];
@@ -233,6 +233,10 @@ Ext.define('Traccar.view.MapMarkerController', {
                 position.get('longitude'),
                 position.get('latitude')
             ]);
+            minx = minx ? Math.min(point[0], minx) : point[0];
+            miny = miny ? Math.min(point[1], miny) : point[1];
+            maxx = maxx ? Math.max(point[0], maxx) : point[0];
+            maxy = maxy ? Math.max(point[1], maxy) : point[1];
             geometry = new ol.geom.Point(point);
             marker = new ol.Feature(geometry);
             marker.set('record', position);
@@ -242,6 +246,15 @@ Ext.define('Traccar.view.MapMarkerController', {
             marker.setStyle(style);
             this.reportMarkers[position.get('id')] = marker;
             this.getView().getReportSource().addFeature(marker);
+        }
+        if (minx !== maxx || miny !== maxy) {
+            this.getView().getMapView().fit([minx, miny, maxx, maxy], this.getView().getMap().getSize());
+        } else if (geometry) {
+            this.getView().getMapView().fit(geometry, this.getView().getMap().getSize());
+        }
+        if (Traccar.app.hasEventId) {
+            this.fireEvent('selectreport', data[0], false);
+            Traccar.app.hasEventId = false;
         }
     },
 

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -214,8 +214,7 @@ Ext.define('Traccar.view.ReportController', {
                 callback: function (records, operation, success) {
                     if (success) {
                         Ext.getStore('ReportRoute').add(records);
-                        if (this.singleEvent && records.length > 0) {
-                            this.singleEvent = false;
+                        if (records.length === 1) {
                             this.fireEvent('selectreport', records[0], false);
                         }
                     }
@@ -225,7 +224,6 @@ Ext.define('Traccar.view.ReportController', {
     },
 
     showSingleEvent: function (eventId) {
-        this.singleEvent = true;
         this.lookupReference('reportTypeField').setValue('events');
         Ext.getStore('Events').load({
             id: eventId,

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -210,9 +210,14 @@ Ext.define('Traccar.view.ReportController', {
                 params: {
                     id: positionIds
                 },
+                scope: this,
                 callback: function (records, operation, success) {
                     if (success) {
                         Ext.getStore('ReportRoute').add(records);
+                        if (this.singleEvent) {
+                            this.singleEvent = false;
+                            this.fireEvent('selectreport', records[0], false);
+                        }
                     }
                 }
             });
@@ -220,6 +225,7 @@ Ext.define('Traccar.view.ReportController', {
     },
 
     showSingleEvent: function (eventId) {
+        this.singleEvent = true;
         this.lookupReference('reportTypeField').setValue('events');
         Ext.getStore('Events').load({
             id: eventId,

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -32,7 +32,8 @@ Ext.define('Traccar.view.ReportController', {
         listen: {
             controller: {
                 '*': {
-                    selectdevice: 'selectDevice'
+                    selectdevice: 'selectDevice',
+                    showsingleevent: 'showSingleEvent'
                 },
                 'map': {
                     selectreport: 'selectReport'
@@ -44,25 +45,6 @@ Ext.define('Traccar.view.ReportController', {
                     load: 'loadEvents'
                 }
             }
-        }
-    },
-
-    init: function () {
-        var eventId = Ext.Object.fromQueryString(window.location.search).eventId;
-        if (eventId) {
-            this.lookupReference('reportTypeField').setValue('events');
-            Ext.getStore('Events').load({
-                params: {
-                    id: eventId
-                },
-                callback: function (records, operation, success) {
-                    if (success) {
-                        Ext.getStore('ReportEvents').add(records);
-                    }
-                }
-            });
-            Traccar.app.hasEventId = true;
-            Traccar.app.removeUrlParameter('eventId');
         }
     },
 
@@ -234,16 +216,31 @@ Ext.define('Traccar.view.ReportController', {
                     }
                 }
             });
-        } else if (Traccar.app.hasEventId && data.length > 0) {
-            this.getView().getSelectionModel().select([data[0]], false, true);
-            this.getView().getView().focusRow(data[0]);
-            if (Traccar.app.isMobile()) {
-                Traccar.app.showReports(true);
-            } else {
-                this.getView().expand();
-            }
-            Traccar.app.hasEventId = false;
         }
+    },
+
+    showSingleEvent: function (eventId) {
+        this.lookupReference('reportTypeField').setValue('events');
+        Ext.getStore('Events').load({
+            id: eventId,
+            scope: this,
+            callback: function (records, operation, success) {
+                if (success) {
+                    Ext.getStore('ReportEvents').add(records);
+                    if (records.length > 0) {
+                        if (!records[0].get('positionId')) {
+                            if (Traccar.app.isMobile()) {
+                                Traccar.app.showReports(true);
+                            } else {
+                                this.getView().expand();
+                            }
+                        }
+                        this.getView().getSelectionModel().select([records[0]], false, true);
+                        this.getView().getView().focusRow(records[0]);
+                    }
+                }
+            }
+        });
     },
 
     downloadFile: function (requestUrl, requestParams) {

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -214,7 +214,7 @@ Ext.define('Traccar.view.ReportController', {
                 callback: function (records, operation, success) {
                     if (success) {
                         Ext.getStore('ReportRoute').add(records);
-                        if (this.singleEvent) {
+                        if (this.singleEvent && records.length > 0) {
                             this.singleEvent = false;
                             this.fireEvent('selectreport', records[0], false);
                         }

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -40,9 +40,29 @@ Ext.define('Traccar.view.ReportController', {
             },
             store: {
                 '#ReportEvents': {
+                    add: 'loadEvents',
                     load: 'loadEvents'
                 }
             }
+        }
+    },
+
+    init: function () {
+        var eventId = Ext.Object.fromQueryString(window.location.search).eventId;
+        if (eventId) {
+            this.lookupReference('reportTypeField').setValue('events');
+            Ext.getStore('Events').load({
+                params: {
+                    id: eventId
+                },
+                callback: function (records, operation, success) {
+                    if (success) {
+                        Ext.getStore('ReportEvents').add(records);
+                    }
+                }
+            });
+            Traccar.app.hasEventId = true;
+            Traccar.app.removeUrlParameter('eventId');
         }
     },
 
@@ -214,6 +234,15 @@ Ext.define('Traccar.view.ReportController', {
                     }
                 }
             });
+        } else if (Traccar.app.hasEventId && data.length > 0) {
+            this.getView().getSelectionModel().select([data[0]], false, true);
+            this.getView().getView().focusRow(data[0]);
+            if (Traccar.app.isMobile()) {
+                Traccar.app.showReports(true);
+            } else {
+                this.getView().expand();
+            }
+            Traccar.app.hasEventId = false;
         }
     },
 


### PR DESCRIPTION
Also fit map view to all markers not only first route.

The logic is not obvious because of asynchronous. I'll try to explain.

- `Application` add function to remove parameter from url and global variable.
- `ReportController.init` check if url has `eventId` parameter and initiate event load process.
Remove `eventId` from url
- `MapMarkerController.loadReport` removed map view fit
- `MapMarkerController.addReportMarkers` calculate `ol.Extent` to fit map view.
Fire 'selectreport' event in case we come here with `eventId` parameter

After this changes if we pass parameter, event will be loaded, position will be loaded and showed on map.

I was thinking, if event does not have linked position, user won't understand what's happen.

- `ReportController.loadEvents` open report panel and highlight event in case we do not have linked position.