### PR TITLE
Fix notifications

### DIFF
--- a/web/app/model/Notification.js
+++ b/web/app/model/Notification.js
@@ -17,7 +17,7 @@
 
 Ext.define('Traccar.model.Notification', {
     extend: 'Ext.data.Model',
-    identifier: 'negative',
+    idProperty: 'type',
 
     fields: [{
         name: 'id',
@@ -31,12 +31,10 @@ Ext.define('Traccar.model.Notification', {
     }, {
         name: 'attributes'
     }, {
-        name: 'attributes.web',
-        type: 'bool',
-        mapping: 'attributes.web'
+        name: 'web',
+        type: 'bool'
     }, {
-        name: 'attributes.mail',
-        type: 'bool',
-        mapping: 'attributes.mail'
+        name: 'mail',
+        type: 'bool'
     }]
 });

--- a/web/app/store/Notifications.js
+++ b/web/app/store/Notifications.js
@@ -22,5 +22,7 @@ Ext.define('Traccar.store.Notifications', {
     proxy: {
         type: 'rest',
         url: 'api/users/notifications'
-    }
+    },
+    sortOnLoad: true,
+    sorters: { property: 'type', direction : 'ASC' }
 });

--- a/web/app/view/Notifications.js
+++ b/web/app/view/Notifications.js
@@ -24,7 +24,7 @@ Ext.define('Traccar.view.Notifications', {
     ],
 
     controller: 'notificationsController',
-    store: 'AllNotifications',
+    store: 'Notifications',
 
     selModel: {
         selType: 'cellmodel'
@@ -48,14 +48,14 @@ Ext.define('Traccar.view.Notifications', {
             }
         }, {
             text: Strings.notificationWeb,
-            dataIndex: 'attributes.web',
+            dataIndex: 'web',
             xtype: 'checkcolumn',
             listeners: {
                 checkChange: 'onCheckChange'
             }
         }, {
             text: Strings.notificationMail,
-            dataIndex: 'attributes.mail',
+            dataIndex: 'mail',
             xtype: 'checkcolumn',
             listeners: {
                 checkChange: 'onCheckChange'

--- a/web/app/view/NotificationsController.js
+++ b/web/app/view/NotificationsController.js
@@ -24,42 +24,19 @@ Ext.define('Traccar.view.NotificationsController', {
     ],
 
     init: function () {
-        this.userId = this.getView().user.getId();
         this.getView().getStore().load({
-            scope: this,
-            callback: function (records, operation, success) {
-                Ext.create('Traccar.store.Notifications').load({
-                    params: {
-                        userId: this.userId
-                    },
-                    scope: this,
-                    callback: function (records, operation, success) {
-                        if (success) {
-                            this.getView().getStore().loadData(records);
-                        }
-                    }
-                });
+            params: {
+                userId: this.getView().user.getId()
             }
         });
     },
 
     onCheckChange: function (column, rowIndex, checked, eOpts) {
-        var record, attributes = {};
-        record = this.getView().getStore().getAt(rowIndex);
-        if (record.get('attributes.web')) {
-            attributes.web = 'true';
-        }
-        if (record.get('attributes.mail')) {
-            attributes.mail = 'true';
-        }
+        var record = this.getView().getStore().getAt(rowIndex);
         Ext.Ajax.request({
             scope: this,
             url: 'api/users/notifications',
-            jsonData: {
-                userId: this.userId,
-                type: record.get('type'),
-                attributes: attributes
-            },
+            jsonData: record.data,
             callback: function (options, success, response) {
                 if (!success) {
                     Traccar.app.showError(response);


### PR DESCRIPTION
It was miracle coincidence, It looked like working, but shouldn't.

- Used `type` as unique id field
- ` loadData` does not  respect IDs, but `add` does. It just replace records with same id.
- Added `refresh` because it sometimes updates grid with delay or only after scrolling/resizing.

ExtJS does everything and now it works.

Sorry, that missed it before.