### PR TITLE
Align Toasts to bottom right corner

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -212,7 +212,7 @@ Ext.define('Traccar.controller.Root', {
                         if (self.mutePressed()) {
                             self.beep();
                         }
-                        Ext.toast(text, device.get('name'));
+                        Ext.toast(text, device.get('name'), 'br');
                     }
                 }
             }


### PR DESCRIPTION
I think it is more "nice-looking" to have Toasts in bottom right corner than in the middle of the screen.
Also it is more usual.
fix #354 