### PR TITLE
Migrate to openlayers 3.20.0

### DIFF
--- a/web/app/DeviceImages.js
+++ b/web/app/DeviceImages.js
@@ -95,11 +95,5 @@ Ext.define('Traccar.DeviceImages', {
         image.category = category;
 
         return image;
-    },
-
-    rotateImageIcon: function (image, angle) {
-        var svg = this.getImageSvg(image.fill, image.zoom, angle, image.category);
-        image.getImage().src = this.formatSrc(svg);
-        image.angle = angle;
     }
 });

--- a/web/app/GeofenceConverter.js
+++ b/web/app/GeofenceConverter.js
@@ -43,7 +43,7 @@ Ext.define('Traccar.GeofenceConverter', {
                     projection = mapView.getProjection();
                     center = ol.proj.transform([Number(coordinates[1]), Number(coordinates[0])], 'EPSG:4326', projection);
                     resolutionAtEquator = mapView.getResolution();
-                    pointResolution = projection.getPointResolution(resolutionAtEquator, center);
+                    pointResolution = ol.proj.getPointResolution(projection, resolutionAtEquator, center);
                     resolutionFactor = resolutionAtEquator / pointResolution;
                     radius = (Number(coordinates[2]) / ol.proj.METERS_PER_UNIT.m) * resolutionFactor;
                     geometry = new ol.geom.Circle(center, radius);

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -134,7 +134,7 @@ Ext.define('Traccar.controller.Root', {
 
             Ext.Ajax.request({
                 url: 'api/devices',
-                success: function(response) {
+                success: function (response) {
                     self.updateDevices(Ext.decode(response.responseText));
                 }
             });
@@ -144,12 +144,12 @@ Ext.define('Traccar.controller.Root', {
                 headers: {
                     Accept: 'application/json'
                 },
-                success: function(response) {
+                success: function (response) {
                     self.updatePositions(Ext.decode(response.responseText));
                 }
             });
 
-            setTimeout(function() {
+            setTimeout(function () {
                 self.asyncUpdate(false);
             }, Traccar.Style.reconnectTimeout);
         };
@@ -186,7 +186,7 @@ Ext.define('Traccar.controller.Root', {
     },
 
     updatePositions: function (array) {
-        var i, store, data, entity;
+        var i, store, entity;
         store = Ext.getStore('LatestPositions');
         for (i = 0; i < array.length; i++) {
             entity = store.findRecord('deviceId', array[i].deviceId, 0, false, false, true);

--- a/web/app/view/BaseMap.js
+++ b/web/app/view/BaseMap.js
@@ -122,7 +122,7 @@ Ext.define('Traccar.view.BaseMap', {
         this.map.on('click', function (e) {
             this.map.forEachFeatureAtPixel(e.pixel, function (feature, layer) {
                 this.fireEvent('selectfeature', feature);
-            }, this);
+            }.bind(this));
         }, this);
     },
 

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -92,7 +92,8 @@ Ext.define('Traccar.view.MapMarkerController', {
                 style = marker.getStyle();
                 if (style.getImage().fill !== this.getDeviceColor(device) ||
                         style.getImage().category !== device.get('category')) {
-                    marker.setStyle(this.updateDeviceMarker(style, this.getDeviceColor(device), device.get('category')));
+                    this.updateDeviceMarker(style, this.getDeviceColor(device), device.get('category'));
+                    marker.changed();
                 }
                 if (style.getText().getText() !== device.get('name')) {
                     style.getText().setText(device.get('name'));
@@ -144,7 +145,7 @@ Ext.define('Traccar.view.MapMarkerController', {
             marker = this.latestMarkers[deviceId];
             style = marker.getStyle();
             if (style.getImage().angle !== position.get('course')) {
-                Traccar.DeviceImages.rotateImageIcon(style.getImage(), position.get('course'));
+                this.rotateMarker(style, position.get('course'));
             }
             marker.setGeometry(geometry);
         } else {
@@ -327,10 +328,15 @@ Ext.define('Traccar.view.MapMarkerController', {
                 style.getImage().category);
         text = style.getText();
         text.setOffsetY(-image.getSize()[1] / 2 - Traccar.Style.mapTextOffset);
-        return new ol.style.Style({
-            image: image,
-            text: text
-        });
+        style.setText(text);
+        style.setImage(image);
+    },
+
+    rotateMarker: function (style, angle) {
+        style.setImage(Traccar.DeviceImages.getImageIcon(style.getImage().fill,
+                style.getImage().zoom,
+                angle,
+                style.getImage().category));
     },
 
     updateDeviceMarker: function (style, color, category) {
@@ -341,21 +347,19 @@ Ext.define('Traccar.view.MapMarkerController', {
                 category);
         text = style.getText();
         text.setOffsetY(-image.getSize()[1] / 2 - Traccar.Style.mapTextOffset);
-        return new ol.style.Style({
-            image: image,
-            text: text
-        });
+        style.setText(text);
+        style.setImage(image);
     },
 
     selectMarker: function (marker, center) {
         if (this.selectedMarker) {
-            this.selectedMarker.setStyle(
-                this.resizeMarker(this.selectedMarker.getStyle(), false));
+            this.resizeMarker(this.selectedMarker.getStyle(), false);
+            this.selectedMarker.changed();
         }
 
         if (marker) {
-            marker.setStyle(
-                this.resizeMarker(marker.getStyle(), true));
+            this.resizeMarker(marker.getStyle(), true);
+            marker.changed();
             if (center) {
                 this.getView().getMapView().setCenter(marker.getGeometry().getCoordinates());
             }

--- a/web/load.js
+++ b/web/load.js
@@ -111,7 +111,7 @@
 
     extjsVersion = '6.2.0';
     fontAwesomeVersion = '4.7.0';
-    olVersion = '3.19.1';
+    olVersion = '3.20.0';
 
     if (debugMode) {
         addScriptFile('//cdnjs.cloudflare.com/ajax/libs/extjs/' + extjsVersion + '/ext-all-debug.js');

--- a/web/simple/index.html
+++ b/web/simple/index.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Traccar</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.19.1/ol.css" type="text/css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.20.0/ol.css" type="text/css">
 </head>
 <body style="margin: 0; padding: 0;">
 <div id="map" style="width: 100%; height: 100%; position:fixed;"></div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.19.1/ol.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.20.0/ol.js" type="text/javascript"></script>
 <script id="loadScript" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Key changes
- Followed migration notes https://github.com/openlayers/ol3/releases/tag/v3.20.0
- Used style.setImage() new function
- Style fixes in `Root.js`

fix for https://www.traccar.org/forums/topic/device-course-wrong-on-map/