### PR TITLE
Save toggles state in user/server attributes

### DIFF
--- a/web/app/view/Map.js
+++ b/web/app/view/Map.js
@@ -48,7 +48,6 @@ Ext.define('Traccar.view.Map', {
             reference: 'showGeofencesButton',
             glyph: 'xf21d@FontAwesome',
             enableToggle: true,
-            pressed: true,
             tooltip: Strings.sharedGeofences
         }, {
             xtype: 'button',
@@ -70,7 +69,6 @@ Ext.define('Traccar.view.Map', {
             glyph: 'xf1f7@FontAwesome',
             tooltip: Strings.sharedMute,
             tooltipType: 'title',
-            pressed : true,
             enableToggle: true,
             listeners: {
                 toggle: function (button, pressed) {

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -27,7 +27,8 @@ Ext.define('Traccar.view.MapController', {
         listen: {
             controller: {
                 '*': {
-                    mapstaterequest: 'getMapState'
+                    mapstaterequest: 'getMapState',
+                    togglestaterequest: 'getToggleState'
                 }
             },
             store: {
@@ -44,6 +45,14 @@ Ext.define('Traccar.view.MapController', {
     init: function () {
         this.callParent();
         this.lookupReference('showReportsButton').setVisible(Traccar.app.isMobile());
+        this.lookupReference('deviceFollowButton').setPressed(
+                Traccar.app.getAttributePreference('web.followToggle', 'false') === 'true');
+        this.lookupReference('showGeofencesButton').setPressed(
+                Traccar.app.getAttributePreference('web.geofenceToggle', 'true') === 'true');
+        this.lookupReference('showLiveRoutes').setPressed(
+                Traccar.app.getAttributePreference('web.liveRouteToggle', 'false') === 'true');
+        Ext.getCmp('muteButton').setPressed(
+                Traccar.app.getAttributePreference('web.muteToggle', 'true') === 'true');
     },
 
     showReports: function () {
@@ -66,6 +75,15 @@ Ext.define('Traccar.view.MapController', {
         center = ol.proj.transform(this.getView().getMapView().getCenter(), projection, 'EPSG:4326');
         zoom = this.getView().getMapView().getZoom();
         this.fireEvent('mapstate', center[1], center[0], zoom);
+    },
+
+    getToggleState: function () {
+        var state = {};
+        state['web.followToggle'] = this.lookupReference('deviceFollowButton').pressed.toString();
+        state['web.geofenceToggle'] = this.lookupReference('showGeofencesButton').pressed.toString();
+        state['web.liveRouteToggle'] = this.lookupReference('showLiveRoutes').pressed.toString();
+        state['web.muteToggle'] = Ext.getCmp('muteButton').pressed.toString();
+        this.fireEvent('togglestate', state);
     },
 
     getGeofenceStyle: function (label) {

--- a/web/app/view/MapPickerDialogController.js
+++ b/web/app/view/MapPickerDialogController.js
@@ -24,7 +24,8 @@ Ext.define('Traccar.view.MapPickerDialogController', {
         listen: {
             controller: {
                 '*': {
-                    mapstate: 'setMapState'
+                    mapstate: 'setMapState',
+                    togglestate: 'setToggleState'
                 }
             }
         }
@@ -34,9 +35,18 @@ Ext.define('Traccar.view.MapPickerDialogController', {
         this.fireEvent('mapstaterequest');
     },
 
+    getToggleState: function (button) {
+        this.fireEvent('togglestaterequest');
+    },
+
     setMapState: function (lat, lon, zoom) {
         this.lookupReference('latitude').setValue(lat);
         this.lookupReference('longitude').setValue(lon);
         this.lookupReference('zoom').setValue(zoom);
+    },
+
+    setToggleState: function (state) {
+        var record = this.getView().down('form').getRecord();
+        record.set('attributes', Ext.merge(record.get('attributes'), state));
     }
 });

--- a/web/app/view/ServerDialog.js
+++ b/web/app/view/ServerDialog.js
@@ -125,6 +125,12 @@ Ext.define('Traccar.view.ServerDialog', {
         tooltip: Strings.sharedGetMapState,
         tooltipType: 'title'
     }, {
+        glyph: 'xf205@FontAwesome',
+        minWidth: 0,
+        handler: 'getToggleState',
+        tooltip: Strings.sharedGetToggleState,
+        tooltipType: 'title'
+    }, {
         xtype: 'tbfill'
     }, {
         glyph: 'xf00c@FontAwesome',

--- a/web/app/view/UserDialog.js
+++ b/web/app/view/UserDialog.js
@@ -163,6 +163,12 @@ Ext.define('Traccar.view.UserDialog', {
         tooltip: Strings.sharedGetMapState,
         tooltipType: 'title'
     }, {
+        glyph: 'xf205@FontAwesome',
+        minWidth: 0,
+        handler: 'getToggleState',
+        tooltip: Strings.sharedGetToggleState,
+        tooltipType: 'title'
+    }, {
         glyph: 'xf003@FontAwesome',
         minWidth: 0,
         handler: 'testMail',

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -35,6 +35,7 @@
     "sharedHourAbbreviation": "h",
     "sharedMinuteAbbreviation": "m",
     "sharedGetMapState": "Get Map State",
+    "sharedGetToggleState": "Get Toggle State",
     "sharedAttributeAlias": "Attribute Alias",
     "sharedAttributeAliases": "Attribute Aliases",
     "sharedAlias": "Alias",


### PR DESCRIPTION
fix #338 and fix #303 

I treat attributes as string because if we add them manually they will be string.
Also boolean attributes will cause wrong behavior of `getAttributePreference` function. 

Server dialog:
![image](https://cloud.githubusercontent.com/assets/5688080/21389982/40d1d4cc-c7a6-11e6-8455-a7f4abd814cb.png)


User dialog:
![image](https://cloud.githubusercontent.com/assets/5688080/21389923/f3910d18-c7a5-11e6-8078-7bf2a725afa9.png)
