### PR TITLE
Add support for custom report colors

### DIFF
--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -276,14 +276,26 @@ Ext.define('Traccar.view.MapMarkerController', {
         }
     },
 
-    getRouteStyle: function (deviceId) {
-        var index = 0;
-        if (deviceId !== undefined) {
-            index = deviceId % Traccar.Style.mapRouteColor.length;
+    getReportColor: function (deviceId) {
+        var index, reportColor, device = Ext.getStore('Devices').getById(deviceId);
+        if (device) {
+            reportColor = device.get('attributes')['web.reportColor'];
         }
+        if (reportColor) {
+            return reportColor;
+        } else {
+            index = 0;
+            if (deviceId !== undefined) {
+                index = deviceId % Traccar.Style.mapRouteColor.length;
+            }
+            return Traccar.Style.mapRouteColor[index];
+        }
+    },
+
+    getRouteStyle: function (deviceId) {
         return new ol.style.Style({
             stroke: new ol.style.Stroke({
-                color: Traccar.Style.mapRouteColor[index],
+                color: this.getReportColor(deviceId),
                 width: Traccar.Style.mapRouteWidth
             })
         });
@@ -313,11 +325,7 @@ Ext.define('Traccar.view.MapMarkerController', {
     },
 
     getReportMarker: function (deviceId, angle) {
-        var index = 0;
-        if (deviceId !== undefined) {
-            index = deviceId % Traccar.Style.mapRouteColor.length;
-        }
-        return this.getMarkerStyle(false, Traccar.Style.mapRouteColor[index], angle, 'arrow');
+        return this.getMarkerStyle(false, this.getReportColor(deviceId), angle, 'arrow');
     },
 
     resizeMarker: function (style, zoom) {

--- a/web/load.js
+++ b/web/load.js
@@ -1,5 +1,5 @@
 (function () {
-    var debugMode, touchMode, locale, localeParameter, extjsVersion, fontAwesomeVersion, olVersion;
+    var debugMode, touchMode, locale, localeParameter, extjsVersion, fontAwesomeVersion, olVersion, i, language, languages;
 
     function addStyleFile(file) {
         var link = document.createElement('link');
@@ -78,13 +78,13 @@
     localeParameter = window.location.search.match(/locale=([^&#]+)/);
     locale.language = localeParameter && localeParameter[1];
     if (!(locale.language in locale.languages)) {
-        var languages = window.navigator.languages !== undefined ? window.navigator.languages.slice() : [];
-        var language = window.navigator.userLanguage || window.navigator.language;
+        languages = window.navigator.languages !== undefined ? window.navigator.languages.slice() : [];
+        language = window.navigator.userLanguage || window.navigator.language;
         languages.push(language);
-        languages.push(language.substr(0,2));
-        languages.push("en"); //default
-        for (var i = 0; i < languages.length; i ++) {
-            var language = languages[i].replace("-", "_");
+        languages.push(language.substr(0, 2));
+        languages.push('en'); //default
+        for (i = 0; i < languages.length; i++) {
+            language = languages[i].replace('-', '_');
             if (language in locale.languages) {
                 locale.language = language;
                 break;


### PR DESCRIPTION
Can't find where, but remember somebody asked it.
Used device attribute `web.reportColor`. Accept any html color without validation, if it is not valid, line will be black and arrows green. (black is default for openlayers, green is in our svg files)

![image](https://cloud.githubusercontent.com/assets/5688080/21420271/8ea64284-c84e-11e6-9eb7-f70b8852e282.png)

Also fixed style issues in `load.js`