### PR TITLE
Add an option to not show report markers

### DIFF
--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -240,15 +240,17 @@ Ext.define('Traccar.view.MapMarkerController', {
                 maxx = Math.max(point[0], maxx);
                 maxy = Math.max(point[1], maxy);
             }
-            geometry = new ol.geom.Point(point);
-            marker = new ol.Feature(geometry);
-            marker.set('record', position);
-            style = this.getReportMarker(position.get('deviceId'), position.get('course'));
-            /*style.getText().setText(
-                Ext.Date.format(position.get('fixTime'), Traccar.Style.dateTimeFormat24));*/
-            marker.setStyle(style);
-            this.reportMarkers[position.get('id')] = marker;
-            this.getView().getMarkersSource().addFeature(marker);
+            if (store.showMarkers !== false) {
+                geometry = new ol.geom.Point(point);
+                marker = new ol.Feature(geometry);
+                marker.set('record', position);
+                style = this.getReportMarker(position.get('deviceId'), position.get('course'));
+                /*style.getText().setText(
+                    Ext.Date.format(position.get('fixTime'), Traccar.Style.dateTimeFormat24));*/
+                marker.setStyle(style);
+                this.reportMarkers[position.get('id')] = marker;
+                this.getView().getMarkersSource().addFeature(marker);
+            }
         }
         if (minx !== maxx || miny !== maxy) {
             this.getView().getMapView().fit([minx, miny, maxx, maxy], this.getView().getMap().getSize());

--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -245,8 +245,6 @@ Ext.define('Traccar.view.MapMarkerController', {
                 marker = new ol.Feature(geometry);
                 marker.set('record', position);
                 style = this.getReportMarker(position.get('deviceId'), position.get('course'));
-                /*style.getText().setText(
-                    Ext.Date.format(position.get('fixTime'), Traccar.Style.dateTimeFormat24));*/
                 marker.setStyle(style);
                 this.reportMarkers[position.get('id')] = marker;
                 this.getView().getMarkersSource().addFeature(marker);

--- a/web/app/view/ReportConfigController.js
+++ b/web/app/view/ReportConfigController.js
@@ -57,8 +57,9 @@ Ext.define('Traccar.view.ReportConfigController', {
         } else if (eventType.length === this.lookupReference('eventTypeField').getStore().getCount() - 1) {
             eventType = [Traccar.store.ReportEventTypes.allEvents];
         }
-        this.getView().callingPanel.chartType = this.lookupReference('chartTypeField').getValue();
         this.getView().callingPanel.eventType = eventType;
+        this.getView().callingPanel.chartType = this.lookupReference('chartTypeField').getValue();
+        this.getView().callingPanel.showMarkers = this.lookupReference('showMarkersField').getValue();
         this.getView().callingPanel.fromDate = this.lookupReference('fromDateField').getValue();
         this.getView().callingPanel.fromTime = this.lookupReference('fromTimeField').getValue();
         this.getView().callingPanel.toDate = this.lookupReference('toDateField').getValue();

--- a/web/app/view/ReportConfigDialog.js
+++ b/web/app/view/ReportConfigDialog.js
@@ -67,6 +67,13 @@ Ext.define('Traccar.view.ReportConfigDialog', {
         displayField: 'name',
         queryMode: 'local'
     }, {
+        fieldLabel: Strings.reportShowMarkers,
+        xtype: 'checkbox',
+        reference: 'showMarkersField',
+        inputValue: true,
+        uncheckedValue: false,
+        value: true
+    }, {
         xtype: 'fieldcontainer',
         layout: 'hbox',
         items: [{

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -79,6 +79,9 @@ Ext.define('Traccar.view.ReportController', {
         if (this.chartType !== undefined) {
             dialog.lookupReference('chartTypeField').setValue(this.chartType);
         }
+        if (this.showMarkers !== undefined) {
+            dialog.lookupReference('showMarkersField').setValue(this.showMarkers);
+        }
         if (this.fromDate !== undefined) {
             dialog.lookupReference('fromDateField').setValue(this.fromDate);
         }
@@ -125,6 +128,7 @@ Ext.define('Traccar.view.ReportController', {
                 } else {
                     store = this.getGrid().getStore();
                 }
+                store.showMarkers = this.showMarkers;
                 store.load({
                     params: {
                         deviceId: this.deviceId,
@@ -207,6 +211,7 @@ Ext.define('Traccar.view.ReportController', {
         from = new Date(trip.get('startTime'));
         to = new Date(trip.get('endTime'));
         Ext.getStore('ReportRoute').removeAll();
+        Ext.getStore('ReportRoute').showMarkers = this.showMarkers;
         Ext.getStore('ReportRoute').load({
             params: {
                 deviceId: trip.get('deviceId'),
@@ -243,6 +248,7 @@ Ext.define('Traccar.view.ReportController', {
                 scope: this,
                 callback: function (records, operation, success) {
                     if (success) {
+                        Ext.getStore('ReportRoute').showMarkers = this.showMarkers;
                         Ext.getStore('ReportRoute').add(records);
                         if (records.length === 1) {
                             this.fireEvent('selectreport', records[0], false);

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -189,6 +189,7 @@
     "reportConfigure": "Configure",
     "reportEventTypes": "Event Types",
     "reportChartType": "Chart Type",
+    "reportShowMarkers": "Show Markers",
     "reportExport": "Export",
     "reportDeviceName": "Device Name",
     "reportAverageSpeed": "Average Speed",


### PR DESCRIPTION
Added option to report config (checked by default)

![image](https://cloud.githubusercontent.com/assets/5688080/21562113/90da790e-ce97-11e6-8ae9-108c29841e6d.png)

I decided to pass its state via store to map controller.

All report types are affected.

![image](https://cloud.githubusercontent.com/assets/5688080/21562136/d9a93b48-ce97-11e6-9070-100849e38344.png)

![image](https://cloud.githubusercontent.com/assets/5688080/21562180/80f82f08-ce98-11e6-96eb-52ec6deb1880.png)

