### PR TITLE
Fix interface sliding on mobile

### DIFF
--- a/web/load.js
+++ b/web/load.js
@@ -21,7 +21,7 @@
         svg.setAttribute('id', id);
         svg.setAttribute('data', file);
         svg.setAttribute('type', 'image/svg+xml');
-        svg.setAttribute('style', 'visibility:hidden');
+        svg.setAttribute('style', 'visibility:hidden;position:absolute;left:-100px;');
         document.body.appendChild(svg);
     }
 


### PR DESCRIPTION
The best way is `display:none` but in most browsers images are not loaded.

Just moved outside visible area.