### PR TITLE
Implement base controller for windows with EditToolbar

### DIFF
--- a/web/app/view/AttributeAliasesController.js
+++ b/web/app/view/AttributeAliasesController.js
@@ -17,13 +17,17 @@
  */
 
 Ext.define('Traccar.view.AttributeAliasesController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.attributeAliases',
 
     requires: [
         'Traccar.view.AttributeAliasDialog',
         'Traccar.model.AttributeAlias'
     ],
+
+    objectModel: 'Traccar.model.AttributeAlias',
+    objectDialog: 'Traccar.view.AttributeAliasDialog',
+    removeTitle: Strings.sharedAttributeAlias,
 
     init: function () {
         var manager = Traccar.app.getUser().get('admin') || Traccar.app.getUser().get('userLimit') > 0;
@@ -47,36 +51,6 @@ Ext.define('Traccar.view.AttributeAliasesController', {
         dialog = Ext.create('Traccar.view.AttributeAliasDialog');
         dialog.down('form').loadRecord(attributeAlias);
         dialog.show();
-    },
-
-    onEditClick: function () {
-        var attributeAlias, dialog;
-        attributeAlias = this.getView().getSelectionModel().getSelection()[0];
-        attributeAlias.store = Ext.getStore('AttributeAliases');
-        dialog = Ext.create('Traccar.view.AttributeAliasDialog');
-        dialog.down('form').loadRecord(attributeAlias);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var attributeAlias = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.sharedAttributeAlias,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            scope: this,
-            fn: function (btn) {
-                var store = Ext.getStore('AttributeAliases');
-                if (btn === 'yes') {
-                    store.remove(attributeAlias);
-                    store.sync();
-                }
-            }
-        });
     },
 
     onSelectionChange: function (selected) {

--- a/web/app/view/AttributesController.js
+++ b/web/app/view/AttributesController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  */
 
 Ext.define('Traccar.view.AttributesController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.attributes',
 
     requires: [
@@ -24,6 +24,10 @@ Ext.define('Traccar.view.AttributesController', {
         'Traccar.store.Attributes',
         'Traccar.model.Attribute'
     ],
+
+    objectModel: 'Traccar.model.Attribute',
+    objectDialog: 'Traccar.view.AttributeDialog',
+    removeTitle: Strings.stateName,
 
     init: function () {
         var store, propertyName, i = 0, attributes;
@@ -67,49 +71,5 @@ Ext.define('Traccar.view.AttributesController', {
         }, this);
 
         this.getView().setStore(store);
-    },
-
-    onAddClick: function () {
-        var attribute, dialog;
-        attribute = Ext.create('Traccar.model.Attribute');
-        attribute.store = this.getView().getStore();
-        dialog = Ext.create('Traccar.view.AttributeDialog');
-        dialog.down('form').loadRecord(attribute);
-        dialog.show();
-    },
-
-    onEditClick: function () {
-        var attribute, dialog;
-        attribute = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.AttributeDialog');
-        dialog.down('form').loadRecord(attribute);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var attribute = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.stateName,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            scope: this,
-            fn: function (btn) {
-                var store = this.getView().getStore();
-                if (btn === 'yes') {
-                    store.remove(attribute);
-                    store.sync();
-                }
-            }
-        });
-    },
-
-    onSelectionChange: function (selected) {
-        var disabled = selected.length > 0;
-        this.lookupReference('toolbarEditButton').setDisabled(disabled);
-        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
     }
 });

--- a/web/app/view/BasePermissionsController.js
+++ b/web/app/view/BasePermissionsController.js
@@ -47,7 +47,7 @@ Ext.define('Traccar.view.BasePermissionsController', {
         });
     },
 
-    onBeforeSelect: function (object, record, index) {
+    onBeforeSelect: function (selection, record, index) {
         var data = {};
         data[this.getView().baseObjectName] = this.getView().baseObject;
         data[this.getView().linkObjectName] = record.getId();
@@ -57,13 +57,14 @@ Ext.define('Traccar.view.BasePermissionsController', {
             jsonData: Ext.util.JSON.encode(data),
             callback: function (options, success, response) {
                 if (!success) {
+                    selection.deselect(record);
                     Traccar.app.showError(response);
                 }
             }
         });
     },
 
-    onBeforeDeselect: function (object, record, index) {
+    onBeforeDeselect: function (selection, record, index) {
         var data = {};
         data[this.getView().baseObjectName] = this.getView().baseObject;
         data[this.getView().linkObjectName] = record.getId();
@@ -74,6 +75,7 @@ Ext.define('Traccar.view.BasePermissionsController', {
             jsonData: Ext.util.JSON.encode(data),
             callback: function (options, success, response) {
                 if (!success) {
+                    selection.select(record);
                     Traccar.app.showError(response);
                 }
             }

--- a/web/app/view/CalendarsController.js
+++ b/web/app/view/CalendarsController.js
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
- * Copyright 2016 Andrey Kunitsyn (andrey@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Andrey Kunitsyn (andrey@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
  */
 
 Ext.define('Traccar.view.CalendarsController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.calendars',
 
     requires: [
@@ -25,50 +25,11 @@ Ext.define('Traccar.view.CalendarsController', {
         'Traccar.model.Calendar'
     ],
 
+    objectModel: 'Traccar.model.Calendar',
+    objectDialog: 'Traccar.view.CalendarDialog',
+    removeTitle: Strings.sharedCalendar,
+
     init: function () {
         Ext.getStore('Calendars').load();
-    },
-
-    onAddClick: function () {
-        var calendar, dialog;
-        calendar = Ext.create('Traccar.model.Calendar');
-        calendar.store = this.getView().getStore();
-        dialog = Ext.create('Traccar.view.CalendarDialog');
-        dialog.down('form').loadRecord(calendar);
-        dialog.show();
-    },
-
-    onEditClick: function () {
-        var calendar, dialog;
-        calendar = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.CalendarDialog');
-        dialog.down('form').loadRecord(calendar);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var calendar = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.sharedCalendar,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            fn: function (btn) {
-                var store = Ext.getStore('Calendars');
-                if (btn === 'yes') {
-                    store.remove(calendar);
-                    store.sync();
-                }
-            }
-        });
-    },
-
-    onSelectionChange: function (selected) {
-        var disabled = selected.length > 0;
-        this.lookupReference('toolbarEditButton').setDisabled(disabled);
-        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
     }
 });

--- a/web/app/view/DevicesController.js
+++ b/web/app/view/DevicesController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  */
 
 Ext.define('Traccar.view.DevicesController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.devices',
 
     requires: [
@@ -47,6 +47,10 @@ Ext.define('Traccar.view.DevicesController', {
         }
     },
 
+    objectModel: 'Traccar.model.Device',
+    objectDialog: 'Traccar.view.DeviceDialog',
+    removeTitle: Strings.sharedDevice,
+
     init: function () {
         var readonly, deviceReadonly;
         deviceReadonly = Traccar.app.getUser().get('deviceReadonly');
@@ -55,49 +59,6 @@ Ext.define('Traccar.view.DevicesController', {
         this.lookupReference('toolbarEditButton').setVisible(!readonly && !deviceReadonly);
         this.lookupReference('toolbarRemoveButton').setVisible(!readonly && !deviceReadonly);
         this.lookupReference('toolbarGeofencesButton').setVisible(!readonly);
-    },
-
-    onAddClick: function () {
-        var device, dialog;
-        device = Ext.create('Traccar.model.Device');
-        device.store = Ext.getStore('Devices');
-        dialog = Ext.create('Traccar.view.DeviceDialog');
-        dialog.down('form').loadRecord(device);
-        dialog.show();
-    },
-
-    onEditClick: function () {
-        var device, dialog;
-        device = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.DeviceDialog');
-        dialog.down('form').loadRecord(device);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var device = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.deviceDialog,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            fn: function (btn) {
-                var store;
-                if (btn === 'yes') {
-                    store = Ext.getStore('Devices');
-                    store.remove(device);
-                    store.sync({
-                        failure: function (batch) {
-                            store.rejectChanges();
-                            Traccar.app.showError(batch.exceptions[0].getError().response);
-                        }
-                    });
-                }
-            }
-        });
     },
 
     onGeofencesClick: function () {

--- a/web/app/view/EditToolbarController.js
+++ b/web/app/view/EditToolbarController.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('Traccar.view.EditToolbarController', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.editToolbarController',
+
+    onAddClick: function () {
+        var dialog, objectInstance = Ext.create(this.objectModel);
+        objectInstance.store = this.getView().getStore();
+        dialog = Ext.create(this.objectDialog);
+        dialog.down('form').loadRecord(objectInstance);
+        dialog.show();
+    },
+
+    onEditClick: function () {
+        var dialog, objectInstance = this.getView().getSelectionModel().getSelection()[0];
+        dialog = Ext.create(this.objectDialog);
+        dialog.down('form').loadRecord(objectInstance);
+        dialog.show();
+    },
+
+    onRemoveClick: function () {
+        var objectInstance = this.getView().getSelectionModel().getSelection()[0];
+        Ext.Msg.show({
+            title: this.removeTitle,
+            message: Strings.sharedRemoveConfirm,
+            buttons: Ext.Msg.YESNO,
+            buttonText: {
+                yes: Strings.sharedRemove,
+                no: Strings.sharedCancel
+            },
+            fn: function (btn) {
+                var store = objectInstance.store;
+                if (btn === 'yes') {
+                    store.remove(objectInstance);
+                    store.sync({
+                        failure: function (batch) {
+                            store.rejectChanges();
+                            Traccar.app.showError(batch.exceptions[0].getError().response);
+                        }
+                    });
+                }
+            }
+        });
+    },
+
+    onSelectionChange: function (selected) {
+        var disabled = selected.length > 0;
+        this.lookupReference('toolbarEditButton').setDisabled(disabled);
+        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
+    }
+});

--- a/web/app/view/GeofencesController.js
+++ b/web/app/view/GeofencesController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  */
 
 Ext.define('Traccar.view.GeofencesController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.geofences',
 
     requires: [
@@ -29,46 +29,7 @@ Ext.define('Traccar.view.GeofencesController', {
         Ext.getStore('Calendars').load();
     },
 
-    onAddClick: function () {
-        var geofence, dialog;
-        geofence = Ext.create('Traccar.model.Geofence');
-        geofence.store = this.getView().getStore();
-        dialog = Ext.create('Traccar.view.GeofenceDialog');
-        dialog.down('form').loadRecord(geofence);
-        dialog.show();
-    },
-
-    onEditClick: function () {
-        var geofence, dialog;
-        geofence = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.GeofenceDialog');
-        dialog.down('form').loadRecord(geofence);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var geofence = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.sharedGeofence,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            fn: function (btn) {
-                var store = Ext.getStore('Geofences');
-                if (btn === 'yes') {
-                    store.remove(geofence);
-                    store.sync();
-                }
-            }
-        });
-    },
-
-    onSelectionChange: function (selected) {
-        var disabled = selected.length > 0;
-        this.lookupReference('toolbarEditButton').setDisabled(disabled);
-        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
-    }
+    objectModel: 'Traccar.model.Geofence',
+    objectDialog: 'Traccar.view.GeofenceDialog',
+    removeTitle: Strings.sharedGeofence
 });

--- a/web/app/view/GroupsController.js
+++ b/web/app/view/GroupsController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  */
 
 Ext.define('Traccar.view.GroupsController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.groups',
 
     requires: [
@@ -26,42 +26,9 @@ Ext.define('Traccar.view.GroupsController', {
         'Traccar.model.Group'
     ],
 
-    onAddClick: function () {
-        var group, dialog;
-        group = Ext.create('Traccar.model.Group');
-        group.store = this.getView().getStore();
-        dialog = Ext.create('Traccar.view.GroupDialog');
-        dialog.down('form').loadRecord(group);
-        dialog.show();
-    },
-
-    onEditClick: function () {
-        var group, dialog;
-        group = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.GroupDialog');
-        dialog.down('form').loadRecord(group);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var group = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.groupDialog,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            fn: function (btn) {
-                var store = Ext.getStore('Groups');
-                if (btn === 'yes') {
-                    store.remove(group);
-                    store.sync();
-                }
-            }
-        });
-    },
+    objectModel: 'Traccar.model.Group',
+    objectDialog: 'Traccar.view.GroupDialog',
+    removeTitle: Strings.groupDialog,
 
     onGeofencesClick: function () {
         var admin, group;
@@ -82,8 +49,7 @@ Ext.define('Traccar.view.GroupsController', {
 
     onSelectionChange: function (selected) {
         var disabled = selected.length > 0;
-        this.lookupReference('toolbarEditButton').setDisabled(disabled);
-        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
         this.lookupReference('toolbarGeofencesButton').setDisabled(disabled);
+        this.callParent(arguments);
     }
 });

--- a/web/app/view/UsersController.js
+++ b/web/app/view/UsersController.js
@@ -17,7 +17,7 @@
  */
 
 Ext.define('Traccar.view.UsersController', {
-    extend: 'Ext.app.ViewController',
+    extend: 'Traccar.view.EditToolbarController',
     alias: 'controller.users',
 
     requires: [
@@ -31,6 +31,10 @@ Ext.define('Traccar.view.UsersController', {
         'Traccar.view.BaseWindow',
         'Traccar.model.User'
     ],
+
+    objectModel: 'Traccar.model.User',
+    objectDialog: 'Traccar.view.UserDialog',
+    removeTitle: Strings.settingsUser,
 
     init: function () {
         Ext.getStore('Users').load();
@@ -49,34 +53,6 @@ Ext.define('Traccar.view.UsersController', {
         dialog = Ext.create('Traccar.view.UserDialog');
         dialog.down('form').loadRecord(user);
         dialog.show();
-    },
-
-    onEditClick: function () {
-        var user, dialog;
-        user = this.getView().getSelectionModel().getSelection()[0];
-        dialog = Ext.create('Traccar.view.UserDialog');
-        dialog.down('form').loadRecord(user);
-        dialog.show();
-    },
-
-    onRemoveClick: function () {
-        var user = this.getView().getSelectionModel().getSelection()[0];
-        Ext.Msg.show({
-            title: Strings.settingsUser,
-            message: Strings.sharedRemoveConfirm,
-            buttons: Ext.Msg.YESNO,
-            buttonText: {
-                yes: Strings.sharedRemove,
-                no: Strings.sharedCancel
-            },
-            fn: function (btn) {
-                var store = Ext.getStore('Users');
-                if (btn === 'yes') {
-                    store.remove(user);
-                    store.sync();
-                }
-            }
-        });
     },
 
     onDevicesClick: function () {
@@ -172,13 +148,12 @@ Ext.define('Traccar.view.UsersController', {
 
     onSelectionChange: function (selection, selected) {
         var disabled = selected.length === 0;
-        this.lookupReference('toolbarEditButton').setDisabled(disabled);
-        this.lookupReference('toolbarRemoveButton').setDisabled(disabled);
         this.lookupReference('userDevicesButton').setDisabled(disabled);
         this.lookupReference('userGroupsButton').setDisabled(disabled);
         this.lookupReference('userGeofencesButton').setDisabled(disabled);
         this.lookupReference('userNotificationsButton').setDisabled(disabled);
         this.lookupReference('userCalendarsButton').setDisabled(disabled);
         this.lookupReference('userUsersButton').setDisabled(disabled || selected[0].get('userLimit') === 0);
+        this.callParent(arguments);
     }
 });


### PR DESCRIPTION
While fixing #392 I've found something to optimize. Implemented `EditToolbarController` for windows that have "plus/pencil/cross" buttons.

Child must set fields:
- `objectModel`
- `objectDialog` - dialog called for edit
- `removeTitle` - title for remove confirmation window

Also view store must be defined. 