### PR TITLE
Correctly set object store for chained store

### DIFF
--- a/web/app/view/EditToolbarController.js
+++ b/web/app/view/EditToolbarController.js
@@ -22,6 +22,9 @@ Ext.define('Traccar.view.EditToolbarController', {
     onAddClick: function () {
         var dialog, objectInstance = Ext.create(this.objectModel);
         objectInstance.store = this.getView().getStore();
+        if (objectInstance.store instanceof Ext.data.ChainedStore) {
+            objectInstance.store = objectInstance.store.getSource();
+        }
         dialog = Ext.create(this.objectDialog);
         dialog.down('form').loadRecord(objectInstance);
         dialog.show();


### PR DESCRIPTION
Chained store do not have `sync()` function, we have to set source store for new objects.

fix #395 