### PR TITLE
Use more efficient method to lookup store (fix 405)

### DIFF
--- a/web/app/view/MapMarkerController.js
+++ b/web/app/view/MapMarkerController.js
@@ -171,7 +171,7 @@ Ext.define('Traccar.view.MapMarkerController', {
 
         for (i = 0; i < data.length; i++) {
             position = data[i];
-            device = Ext.getStore('Devices').findRecord('id', position.get('deviceId'), 0, false, false, true);
+            device = Ext.getStore('Devices').getById(position.get('deviceId'));
 
             if (device) {
                 this.updateAccuracy(position);
@@ -333,9 +333,9 @@ Ext.define('Traccar.view.MapMarkerController', {
             }
         }
         if (minx !== maxx || miny !== maxy) {
-            this.getView().getMapView().fit([minx, miny, maxx, maxy], this.getView().getMap().getSize());
+            this.getView().getMapView().fit([minx, miny, maxx, maxy]);
         } else if (point) {
-            this.getView().getMapView().fit(new ol.geom.Point(point), this.getView().getMap().getSize());
+            this.getView().getMapView().fit(new ol.geom.Point(point));
         }
     },
 

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -437,7 +437,7 @@ Ext.define('Traccar.view.ReportController', {
         dataIndex: 'geofenceId',
         renderer: function (value) {
             if (value !== 0) {
-                return Ext.getStore('Geofences').findRecord('id', value).get('name');
+                return Ext.getStore('Geofences').getById(value).get('name');
             }
         }
     }],


### PR DESCRIPTION
Used `store.getById()` instead of `store.findRecord('id',...)` fix #405 

Also removed unnecessary parameter from `mapView.fit()` according to openlayers 4.0.0 release notes https://github.com/openlayers/openlayers/releases/tag/v4.0.0