### PR TITLE
Implement SMS commands

### DIFF
--- a/web/app/model/Command.js
+++ b/web/app/model/Command.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,9 @@ Ext.define('Traccar.model.Command', {
     }, {
         name: 'type',
         type: 'string'
+    }, {
+        name: 'textChannel',
+        type: 'boolean'
     }, {
         name: 'attributes'
     }]

--- a/web/app/store/CommandTypes.js
+++ b/web/app/store/CommandTypes.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 Gabor Somogyi (gabor.g.somogyi@gmail.com)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,17 +20,9 @@ Ext.define('Traccar.store.CommandTypes', {
     extend: 'Ext.data.Store',
     fields: ['type', 'name'],
 
-    listeners: {
-        'beforeload' : function (store) {
-            var proxy;
-            proxy = store.getProxy();
-            proxy.setUrl('api/commandtypes?deviceId' + proxy.extraParams.deviceId);
-        }
-    },
-
     proxy: {
         type: 'rest',
-        url: '',
+        url: 'api/commandtypes',
         reader: {
             type: 'json',
             getData: function (data) {
@@ -45,6 +38,11 @@ Ext.define('Traccar.store.CommandTypes', {
                     }
                 });
                 return data;
+            }
+        },
+        listeners: {
+            'exception' : function (proxy, response) {
+                Traccar.app.showError(response);
             }
         }
     }

--- a/web/app/view/CommandDialog.js
+++ b/web/app/view/CommandDialog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,8 +28,19 @@ Ext.define('Traccar.view.CommandDialog', {
     items: {
         xtype: 'form',
         items: [{
+            xtype: 'checkboxfield',
+            name: 'textChannel',
+            reference: 'textChannelCheckBox',
+            inputValue: true,
+            uncheckedValue: false,
+            fieldLabel: Strings.notificationSms,
+            listeners: {
+                change: 'onTextChannelChange'
+            }
+        }, {
             xtype: 'combobox',
             name: 'type',
+            reference: 'commandType',
             fieldLabel: Strings.sharedType,
             store: 'CommandTypes',
             displayField: 'name',

--- a/web/app/view/CommandDialogController.js
+++ b/web/app/view/CommandDialogController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,9 +113,18 @@ Ext.define('Traccar.view.CommandDialogController', {
         });
     },
 
+    onTextChannelChange: function (checkbox, newValue) {
+        var typesStore = this.lookupReference('commandType').getStore();
+        typesStore.getProxy().setExtraParam('textChannel', newValue);
+        typesStore.reload();
+    },
+
     onSendResult: function (options, success, response) {
         if (success) {
-            Ext.toast(Strings.commandSent);
+            Ext.toast({
+                html: Strings.commandSent,
+                align: 'br'
+            });
             this.closeView();
         } else {
             Traccar.app.showError(response);

--- a/web/app/view/DevicesController.js
+++ b/web/app/view/DevicesController.js
@@ -74,28 +74,30 @@ Ext.define('Traccar.view.DevicesController', {
     },
 
     onCommandClick: function () {
-        var device, deviceId, command, dialog, comboStore;
+        var device, deviceId, command, dialog, comboStore, online;
         device = this.getView().getSelectionModel().getSelection()[0];
+        online = device.get('status') === 'online';
         deviceId = device.get('id');
         command = Ext.create('Traccar.model.Command');
         command.set('deviceId', deviceId);
+        command.set('textChannel', !online);
         dialog = Ext.create('Traccar.view.CommandDialog');
         comboStore = dialog.down('form').down('combobox').getStore();
         comboStore.getProxy().setExtraParam('deviceId', deviceId);
         dialog.down('form').loadRecord(command);
+        dialog.lookupReference('textChannelCheckBox').setDisabled(!online);
         dialog.show();
     },
 
     updateButtons: function (selected) {
-        var readonly, deviceReadonly, empty, online;
+        var readonly, deviceReadonly, empty;
         deviceReadonly = Traccar.app.getPreference('deviceReadonly', false) && !Traccar.app.getUser().get('admin');
         readonly = Traccar.app.getPreference('readonly', false) && !Traccar.app.getUser().get('admin');
         empty = selected.getCount() === 0;
-        online = selected.getLastSelected().get('status') === 'online';
         this.lookupReference('toolbarEditButton').setDisabled(empty || readonly || deviceReadonly);
         this.lookupReference('toolbarRemoveButton').setDisabled(empty || readonly || deviceReadonly);
         this.lookupReference('toolbarGeofencesButton').setDisabled(empty || readonly);
-        this.lookupReference('deviceCommandButton').setDisabled(empty || readonly || !online);
+        this.lookupReference('deviceCommandButton').setDisabled(empty || readonly);
     },
 
     onSelectionChange: function (selected) {

--- a/web/app/view/DevicesController.js
+++ b/web/app/view/DevicesController.js
@@ -74,16 +74,20 @@ Ext.define('Traccar.view.DevicesController', {
     },
 
     onCommandClick: function () {
-        var device, deviceId, command, dialog, comboStore, online;
+        var device, deviceId, command, dialog, typesStore, online;
         device = this.getView().getSelectionModel().getSelection()[0];
         online = device.get('status') === 'online';
         deviceId = device.get('id');
+
         command = Ext.create('Traccar.model.Command');
         command.set('deviceId', deviceId);
         command.set('textChannel', !online);
+
         dialog = Ext.create('Traccar.view.CommandDialog');
-        comboStore = dialog.down('form').down('combobox').getStore();
-        comboStore.getProxy().setExtraParam('deviceId', deviceId);
+
+        typesStore = dialog.lookupReference('commandType').getStore();
+        typesStore.getProxy().setExtraParam('deviceId', deviceId);
+
         dialog.down('form').loadRecord(command);
         dialog.lookupReference('textChannelCheckBox').setDisabled(!online);
         dialog.show();


### PR DESCRIPTION
Web-part for https://github.com/tananaev/traccar/pull/2971 and https://github.com/tananaev/traccar/pull/2982

added checkbox for transport
![image](https://cloud.githubusercontent.com/assets/5688080/23652667/a5944878-034b-11e7-83b1-9ac4e2af5f38.png)

Allowed send commands to offline devices, and automatically lock to SMS
![image](https://cloud.githubusercontent.com/assets/5688080/23652726/ced583dc-034b-11e7-9165-e05c6a95e474.png)

Also added exception handler in case something happen while loading supported command types.
