### PR TITLE
Remove selType

### DIFF
--- a/web/app/view/AttributeAliases.js
+++ b/web/app/view/AttributeAliases.js
@@ -27,8 +27,6 @@ Ext.define('Traccar.view.AttributeAliases', {
 
     controller: 'attributeAliases',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar',
         items: ['-', {

--- a/web/app/view/Attributes.js
+++ b/web/app/view/Attributes.js
@@ -26,8 +26,6 @@ Ext.define('Traccar.view.Attributes', {
 
     controller: 'attributes',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar'
     },

--- a/web/app/view/Calendars.js
+++ b/web/app/view/Calendars.js
@@ -28,8 +28,6 @@ Ext.define('Traccar.view.Calendars', {
     controller: 'calendars',
     store: 'Calendars',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar'
     },

--- a/web/app/view/Devices.js
+++ b/web/app/view/Devices.js
@@ -35,8 +35,6 @@ Ext.define('Traccar.view.Devices', {
         this.callParent();
     },
 
-    selType: 'rowmodel',
-
     tbar: {
         componentCls: 'toolbar-header-style',
         items: [{

--- a/web/app/view/Geofences.js
+++ b/web/app/view/Geofences.js
@@ -27,8 +27,6 @@ Ext.define('Traccar.view.Geofences', {
     controller: 'geofences',
     store: 'Geofences',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar'
     },

--- a/web/app/view/Groups.js
+++ b/web/app/view/Groups.js
@@ -27,8 +27,6 @@ Ext.define('Traccar.view.Groups', {
     controller: 'groups',
     store: 'Groups',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar',
         items: [{

--- a/web/app/view/Users.js
+++ b/web/app/view/Users.js
@@ -28,8 +28,6 @@ Ext.define('Traccar.view.Users', {
     controller: 'users',
     store: 'Users',
 
-    selType: 'rowmodel',
-
     tbar: {
         xtype: 'editToolbar',
         items: [{


### PR DESCRIPTION
Just removed `selType` for all views where it was, because selection model is `rowmodel` by default
http://docs.sencha.com/extjs/6.2.0/classic/Ext.grid.Panel.html#cfg-selModel

In other places we use actual `selModel`

fix #428  