### PR TITLE
Initialize stores on application load

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -78,7 +78,9 @@ Ext.define('Traccar.controller.Root', {
         var attribution, eventId;
         Ext.getStore('Groups').load();
         Ext.getStore('Geofences').load();
+        Ext.getStore('Calendars').load();
         Ext.getStore('AttributeAliases').load();
+        this.initReportEventTypesStore();
         Ext.getStore('Devices').load({
             scope: this,
             callback: function () {
@@ -239,5 +241,25 @@ Ext.define('Traccar.controller.Root', {
         if (lat === 0 && lon === 0 && zoom === 0) {
             this.fireEvent('zoomtoalldevices');
         }
+    },
+
+    initReportEventTypesStore: function () {
+        var store = Ext.getStore('ReportEventTypes');
+        store.add({
+            type: Traccar.store.ReportEventTypes.allEvents,
+            name: Strings.eventAll
+        });
+        Ext.create('Traccar.store.AllNotifications').load({
+            scope: this,
+            callback: function (records, operation, success) {
+                var i, value;
+                if (success) {
+                    for (i = 0; i < records.length; i++) {
+                        value = records[i].get('type');
+                        store.add({type: value, name: Traccar.app.getEventString(value)});
+                    }
+                }
+            }
+        });
     }
 });

--- a/web/app/view/AttributeAliases.js
+++ b/web/app/view/AttributeAliases.js
@@ -38,7 +38,7 @@ Ext.define('Traccar.view.AttributeAliases', {
             store: 'Devices',
             displayField: 'name',
             valueField: 'id',
-            typeAhead: true,
+            editable: false,
             listeners: {
                 change: 'onDeviceChange'
             }

--- a/web/app/view/CalendarsController.js
+++ b/web/app/view/CalendarsController.js
@@ -27,9 +27,6 @@ Ext.define('Traccar.view.CalendarsController', {
 
     objectModel: 'Traccar.model.Calendar',
     objectDialog: 'Traccar.view.CalendarDialog',
-    removeTitle: Strings.sharedCalendar,
+    removeTitle: Strings.sharedCalendar
 
-    init: function () {
-        Ext.getStore('Calendars').load();
-    }
 });

--- a/web/app/view/DeviceDistanceDialog.js
+++ b/web/app/view/DeviceDistanceDialog.js
@@ -33,6 +33,7 @@ Ext.define('Traccar.view.DeviceDistanceDialog', {
         store: 'AllDevices',
         displayField: 'name',
         valueField: 'id',
+        editable: false,
         listeners: {
             change: 'onDeviceChange'
         }

--- a/web/app/view/GeofencesController.js
+++ b/web/app/view/GeofencesController.js
@@ -24,11 +24,6 @@ Ext.define('Traccar.view.GeofencesController', {
         'Traccar.model.Geofence'
     ],
 
-    init: function () {
-        Ext.getStore('Geofences').load();
-        Ext.getStore('Calendars').load();
-    },
-
     objectModel: 'Traccar.model.Geofence',
     objectDialog: 'Traccar.view.GeofenceDialog',
     removeTitle: Strings.sharedGeofence

--- a/web/app/view/ReportConfigController.js
+++ b/web/app/view/ReportConfigController.js
@@ -25,28 +25,6 @@ Ext.define('Traccar.view.ReportConfigController', {
         'Traccar.store.AllNotifications'
     ],
 
-    init: function () {
-        var store = this.lookupReference('eventTypeField').getStore();
-        if (store.getCount() === 0) {
-            store.add({
-                type: Traccar.store.ReportEventTypes.allEvents,
-                name: Strings.eventAll
-            });
-            Ext.create('Traccar.store.AllNotifications').load({
-                scope: this,
-                callback: function (records, operation, success) {
-                    var i, value;
-                    if (success) {
-                        for (i = 0; i < records.length; i++) {
-                            value = records[i].get('type');
-                            store.add({type: value, name: Traccar.app.getEventString(value)});
-                        }
-                    }
-                }
-            });
-        }
-    },
-
     onSaveClick: function (button) {
         var eventType;
         this.getView().callingPanel.deviceId = this.lookupReference('deviceField').getValue();


### PR DESCRIPTION
- Load `Geofences` and `Calendars` stores on application launch
- Initialize `ReportEventTypes` store on application launch
- Make two `Device` pickers not-editable 

fix #441 