### PR TITLE
Use cookies to save buttons state instead of User/Server attributes

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -114,9 +114,9 @@ Ext.define('Traccar.controller.Root', {
         this.beepSound.play();
     },
 
-    mutePressed: function () {
-        var muteButton = Ext.getCmp('muteButton');
-        return muteButton && !muteButton.pressed;
+    soundPressed: function () {
+        var soundButton = Ext.getCmp('soundButton');
+        return soundButton && soundButton.pressed;
     },
 
     removeUrlParameter: function (param) {
@@ -231,7 +231,7 @@ Ext.define('Traccar.controller.Root', {
             }
             device = Ext.getStore('Devices').getById(array[i].deviceId);
             if (device) {
-                if (this.mutePressed()) {
+                if (this.soundPressed()) {
                     this.beep();
                 }
                 Ext.toast(text, device.get('name'), 'br');

--- a/web/app/view/Map.js
+++ b/web/app/view/Map.js
@@ -71,23 +71,10 @@ Ext.define('Traccar.view.Map', {
             stateId: 'device-follow-button',
             toggleHandler: 'onFollowClick'
         }, {
-            id: 'muteButton',
-            glyph: 'xf1f7@FontAwesome',
-            tooltip: Strings.sharedMute,
-            pressed: true,
-            stateId: 'mute-button',
-            listeners: {
-                toggle: function (button, pressed) {
-                    if (pressed) {
-                        button.setGlyph('xf1f7@FontAwesome');
-                    } else {
-                        button.setGlyph('xf0a2@FontAwesome');
-                    }
-                }
-            },
-            applyState: function (state) {
-                this.toggle(state.pressed);
-            }
+            id: 'soundButton',
+            glyph: 'xf0a2@FontAwesome',
+            tooltip: Strings.sharedSound,
+            stateId: 'sound-button'
         }, {
             xtype: 'settingsMenu',
             enableToggle: false

--- a/web/app/view/Map.js
+++ b/web/app/view/Map.js
@@ -29,6 +29,15 @@ Ext.define('Traccar.view.Map', {
     title: Strings.mapTitle,
     tbar: {
         componentCls: 'toolbar-header-style',
+        defaults: {
+            xtype: 'button',
+            tooltipType: 'title',
+            stateEvents: ['toggle'],
+            enableToggle: true,
+            stateful: {
+                pressed: true
+            }
+        },
         items: [{
             xtype: 'tbtext',
             html: Strings.mapTitle,
@@ -36,41 +45,37 @@ Ext.define('Traccar.view.Map', {
         }, {
             xtype: 'tbfill'
         }, {
-            xtype: 'button',
-            tooltipType: 'title',
             handler: 'showReports',
             reference: 'showReportsButton',
             glyph: 'xf0f6@FontAwesome',
+            stateful: false,
+            enableToggle: false,
             tooltip: Strings.reportTitle
         }, {
-            xtype: 'button',
-            tooltipType: 'title',
             handler: 'updateGeofences',
             reference: 'showGeofencesButton',
             glyph: 'xf21d@FontAwesome',
-            enableToggle: true,
+            pressed: true,
+            stateId: 'show-geofences-button',
             tooltip: Strings.sharedGeofences
         }, {
-            xtype: 'button',
-            tooltipType: 'title',
             handler: 'showLiveRoutes',
             reference: 'showLiveRoutes',
             glyph: 'xf1b0@FontAwesome',
-            enableToggle: true,
+            stateId: 'show-live-routes-button',
             tooltip: Strings.mapLiveRoutes
         }, {
             reference: 'deviceFollowButton',
             glyph: 'xf05b@FontAwesome',
             tooltip: Strings.deviceFollow,
-            tooltipType: 'title',
-            enableToggle: true,
+            stateId: 'device-follow-button',
             toggleHandler: 'onFollowClick'
         }, {
             id: 'muteButton',
             glyph: 'xf1f7@FontAwesome',
             tooltip: Strings.sharedMute,
-            tooltipType: 'title',
-            enableToggle: true,
+            pressed: true,
+            stateId: 'mute-button',
             listeners: {
                 toggle: function (button, pressed) {
                     if (pressed) {
@@ -78,11 +83,14 @@ Ext.define('Traccar.view.Map', {
                     } else {
                         button.setGlyph('xf0a2@FontAwesome');
                     }
-                },
-                scope: this
+                }
+            },
+            applyState: function (state) {
+                this.toggle(state.pressed);
             }
         }, {
-            xtype: 'settingsMenu'
+            xtype: 'settingsMenu',
+            enableToggle: false
         }]
     },
 

--- a/web/app/view/MapController.js
+++ b/web/app/view/MapController.js
@@ -28,7 +28,6 @@ Ext.define('Traccar.view.MapController', {
             controller: {
                 '*': {
                     mapstaterequest: 'getMapState',
-                    togglestaterequest: 'getToggleState',
                     zoomtoalldevices: 'zoomToAllDevices'
                 }
             },
@@ -46,14 +45,6 @@ Ext.define('Traccar.view.MapController', {
     init: function () {
         this.callParent();
         this.lookupReference('showReportsButton').setVisible(Traccar.app.isMobile());
-        this.lookupReference('deviceFollowButton').setPressed(
-                Traccar.app.getAttributePreference('web.followToggle', 'false') === 'true');
-        this.lookupReference('showGeofencesButton').setPressed(
-                Traccar.app.getAttributePreference('web.geofenceToggle', 'true') === 'true');
-        this.lookupReference('showLiveRoutes').setPressed(
-                Traccar.app.getAttributePreference('web.liveRouteToggle', 'false') === 'true');
-        Ext.getCmp('muteButton').setPressed(
-                Traccar.app.getAttributePreference('web.muteToggle', 'true') === 'true');
     },
 
     showReports: function () {
@@ -76,15 +67,6 @@ Ext.define('Traccar.view.MapController', {
         center = ol.proj.transform(this.getView().getMapView().getCenter(), projection, 'EPSG:4326');
         zoom = this.getView().getMapView().getZoom();
         this.fireEvent('mapstate', center[1], center[0], zoom);
-    },
-
-    getToggleState: function () {
-        var state = {};
-        state['web.followToggle'] = this.lookupReference('deviceFollowButton').pressed.toString();
-        state['web.geofenceToggle'] = this.lookupReference('showGeofencesButton').pressed.toString();
-        state['web.liveRouteToggle'] = this.lookupReference('showLiveRoutes').pressed.toString();
-        state['web.muteToggle'] = Ext.getCmp('muteButton').pressed.toString();
-        this.fireEvent('togglestate', state);
     },
 
     updateGeofences: function () {

--- a/web/app/view/MapPickerDialogController.js
+++ b/web/app/view/MapPickerDialogController.js
@@ -24,8 +24,7 @@ Ext.define('Traccar.view.MapPickerDialogController', {
         listen: {
             controller: {
                 '*': {
-                    mapstate: 'setMapState',
-                    togglestate: 'setToggleState'
+                    mapstate: 'setMapState'
                 }
             }
         }
@@ -35,18 +34,9 @@ Ext.define('Traccar.view.MapPickerDialogController', {
         this.fireEvent('mapstaterequest');
     },
 
-    getToggleState: function (button) {
-        this.fireEvent('togglestaterequest');
-    },
-
     setMapState: function (lat, lon, zoom) {
         this.lookupReference('latitude').setValue(lat);
         this.lookupReference('longitude').setValue(lon);
         this.lookupReference('zoom').setValue(zoom);
-    },
-
-    setToggleState: function (state) {
-        var record = this.getView().down('form').getRecord();
-        record.set('attributes', Ext.merge(record.get('attributes'), state));
     }
 });

--- a/web/app/view/ServerDialog.js
+++ b/web/app/view/ServerDialog.js
@@ -150,12 +150,6 @@ Ext.define('Traccar.view.ServerDialog', {
         tooltip: Strings.sharedGetMapState,
         tooltipType: 'title'
     }, {
-        glyph: 'xf205@FontAwesome',
-        minWidth: 0,
-        handler: 'getToggleState',
-        tooltip: Strings.sharedGetToggleState,
-        tooltipType: 'title'
-    }, {
         xtype: 'tbfill'
     }, {
         glyph: 'xf00c@FontAwesome',

--- a/web/app/view/UserDialog.js
+++ b/web/app/view/UserDialog.js
@@ -202,12 +202,6 @@ Ext.define('Traccar.view.UserDialog', {
         tooltip: Strings.sharedGetMapState,
         tooltipType: 'title'
     }, {
-        glyph: 'xf205@FontAwesome',
-        minWidth: 0,
-        handler: 'getToggleState',
-        tooltip: Strings.sharedGetToggleState,
-        tooltipType: 'title'
-    }, {
         glyph: 'xf003@FontAwesome',
         minWidth: 0,
         handler: 'testNotification',

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -29,7 +29,7 @@
     "sharedAttributes": "Attributes",
     "sharedAttribute": "Attribute",
     "sharedArea": "Area",
-    "sharedSound": "Play Sound",
+    "sharedSound": "Notification Sound",
     "sharedType": "Type",
     "sharedDistance": "Distance",
     "sharedHourAbbreviation": "h",

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -35,7 +35,6 @@
     "sharedHourAbbreviation": "h",
     "sharedMinuteAbbreviation": "m",
     "sharedGetMapState": "Get Map State",
-    "sharedGetToggleState": "Get Toggle State",
     "sharedAttributeAlias": "Attribute Alias",
     "sharedAttributeAliases": "Attribute Aliases",
     "sharedAlias": "Alias",

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -29,7 +29,7 @@
     "sharedAttributes": "Attributes",
     "sharedAttribute": "Attribute",
     "sharedArea": "Area",
-    "sharedMute": "Mute",
+    "sharedSound": "Play Sound",
     "sharedType": "Type",
     "sharedDistance": "Distance",
     "sharedHourAbbreviation": "h",


### PR DESCRIPTION
Removed previous way of saving and optimized toolbar a bit with help of `defaults`

![image](https://cloud.githubusercontent.com/assets/5688080/24294766/abd2a24a-10b9-11e7-95a3-6580f9e4bc06.png)
