### PR TITLE
Save state of panels and add filter to Users dialog

### DIFF
--- a/web/app/view/Main.js
+++ b/web/app/view/Main.js
@@ -41,6 +41,8 @@ Ext.define('Traccar.view.Main', {
         title: Strings.devicesAndState,
         titleCollapse: true,
         floatable: false,
+        stateful: true,
+        stateId: 'devices-and-state-panel',
 
         defaults: {
             split: true,

--- a/web/app/view/State.js
+++ b/web/app/view/State.js
@@ -26,6 +26,9 @@ Ext.define('Traccar.view.State', {
     controller: 'state',
     store: 'Attributes',
 
+    stateful: true,
+    stateId: 'state-grid',
+
     tbar: {
         componentCls: 'toolbar-header-style',
         items: [{

--- a/web/app/view/Users.js
+++ b/web/app/view/Users.js
@@ -21,12 +21,15 @@ Ext.define('Traccar.view.Users', {
     xtype: 'usersView',
 
     requires: [
+        'Ext.grid.filters.Filters',
         'Traccar.view.UsersController',
         'Traccar.view.EditToolbar'
     ],
 
     controller: 'users',
     store: 'Users',
+
+    plugins: 'gridfilters',
 
     tbar: {
         xtype: 'editToolbar',
@@ -89,10 +92,19 @@ Ext.define('Traccar.view.Users', {
             dataIndex: 'name'
         }, {
             text: Strings.userEmail,
-            dataIndex: 'email'
+            dataIndex: 'email',
+            filter: 'string'
         }, {
             text: Strings.userAdmin,
             dataIndex: 'admin'
+        }, {
+            text: Strings.serverReadonly,
+            dataIndex: 'readonly',
+            hidden: true
+        }, {
+            text: Strings.userDeviceReadonly,
+            dataIndex: 'deviceReadonly',
+            hidden: true
         }, {
             text: Strings.userDisabled,
             dataIndex: 'disabled'


### PR DESCRIPTION
- Save state of State panel - columns and collapsed/width in mobile view
- Save state of DevicesAndState panel in desktop view - width and collapsed
- Added filter to email column in Users dialog, added two columns

![image](https://cloud.githubusercontent.com/assets/5688080/24319647/c5a01e52-1143-11e7-9c7d-fe3c4a16faa2.png)

![image](https://cloud.githubusercontent.com/assets/5688080/24319653/ec16c914-1143-11e7-86f6-f520567e553b.png)

I think it is last part of fix #446 
