### PR TITLE
Fix two small deselecting issues

### DIFF
--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -110,8 +110,9 @@ Ext.define('Traccar.view.ReportController', {
     onReportClick: function (button) {
         var reportType, from, to, store, url;
 
-        reportType = this.lookupReference('reportTypeField').getValue();
+        this.getGrid().getSelectionModel().deselectAll();
 
+        reportType = this.lookupReference('reportTypeField').getValue();
         if (reportType && (this.deviceId || this.groupId)) {
             from = new Date(
                 this.fromDate.getFullYear(), this.fromDate.getMonth(), this.fromDate.getDate(),

--- a/web/app/view/StateController.js
+++ b/web/app/view/StateController.js
@@ -167,8 +167,10 @@ Ext.define('Traccar.view.StateController', {
     },
 
     clearReport: function (store) {
-        this.position = null;
-        Ext.getStore('Attributes').removeAll();
+        if (!this.deviceId) {
+            this.position = null;
+            Ext.getStore('Attributes').removeAll();
+        }
     },
 
     onSelectionChange: function (selected, records) {


### PR DESCRIPTION
- Clear report was causing clear State even if Device was selected
- If report was selected and "Show" button clicked second time, selection on map was reseted, but selection in report grid not. Just reset selection in report grid on every "Show" button click for consistence.