### PR TITLE
Save panel states independently for desktop and mobile

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -143,7 +143,7 @@ Ext.define('Traccar.controller.Root', {
                 success: function (response) {
                     self.updateDevices(Ext.decode(response.responseText));
                 },
-                failure: function(response) {
+                failure: function (response) {
                     if (response.status === 401) {
                         window.location.reload();
                     }

--- a/web/app/view/MainMobile.js
+++ b/web/app/view/MainMobile.js
@@ -47,7 +47,8 @@ Ext.define('Traccar.view.MainMobile', {
             collapsed: true,
             collapseMode: 'mini',
             titleCollapse: true,
-            floatable: false
+            floatable: false,
+            stateId: 'mobile-state-grid'
         }, {
             region: 'center',
             xtype: 'mapView',
@@ -60,7 +61,8 @@ Ext.define('Traccar.view.MainMobile', {
             flex: 1,
             collapsed: true,
             titleCollapse: true,
-            floatable: false
+            floatable: false,
+            stateId: 'mobile-devices-grid'
         }]
     }, {
         xtype: 'reportView'


### PR DESCRIPTION
Save grid states with different ids for mobile and desktop layout

fix #462 