### PR TITLE
Convert speed and distance for known attributes

### DIFF
--- a/web/app/store/DeviceAttributes.js
+++ b/web/app/store/DeviceAttributes.js
@@ -23,7 +23,8 @@ Ext.define('Traccar.store.DeviceAttributes', {
     data: [{
         key: 'speedLimit',
         name: Strings.attributeSpeedLimit,
-        type: 'number'
+        type: 'number',
+        convert: 'speed'
     }, {
         key: 'report.ignoreOdometer',
         name: Strings.attributeReportIgnoreOdometer,
@@ -31,11 +32,13 @@ Ext.define('Traccar.store.DeviceAttributes', {
     }, {
         key: 'maintenance.start',
         name: Strings.attributeMaintenanceStart,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'maintenance.interval',
         name: Strings.attributeMaintenanceInterval,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'web.reportColor',
         name: Strings.attributeWebReportColor,

--- a/web/app/store/DistanceUnits.js
+++ b/web/app/store/DistanceUnits.js
@@ -33,13 +33,13 @@ Ext.define('Traccar.store.DistanceUnits', {
         factor: 0.000539957
     }],
 
-    convertValue: function (value, unit) {
+    convertValue: function (value, unit, back) {
         var model;
         if (!unit) {
             unit = 'km';
         }
         model = this.findRecord('key', unit);
-        return value * model.get('factor');
+        return back ? value / model.get('factor') : value * model.get('factor');
     },
 
     formatValue: function (value, unit) {

--- a/web/app/store/GroupAttributes.js
+++ b/web/app/store/GroupAttributes.js
@@ -23,7 +23,8 @@ Ext.define('Traccar.store.GroupAttributes', {
     data: [{
         key: 'speedLimit',
         name: Strings.attributeSpeedLimit,
-        type: 'number'
+        type: 'number',
+        convert: 'speed'
     }, {
         key: 'report.ignoreOdometer',
         name: Strings.attributeReportIgnoreOdometer,
@@ -31,11 +32,13 @@ Ext.define('Traccar.store.GroupAttributes', {
     }, {
         key: 'maintenance.start',
         name: Strings.attributeMaintenanceStart,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'maintenance.interval',
         name: Strings.attributeMaintenanceInterval,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'processing.copyAttributes',
         name: Strings.attributeProcessingCopyAttributes,

--- a/web/app/store/ServerAttributes.js
+++ b/web/app/store/ServerAttributes.js
@@ -23,15 +23,18 @@ Ext.define('Traccar.store.ServerAttributes', {
     data: [{
         key: 'speedLimit',
         name: Strings.attributeSpeedLimit,
-        type: 'number'
+        type: 'number',
+        convert: 'speed'
     }, {
         key: 'maintenance.start',
         name: Strings.attributeMaintenanceStart,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'maintenance.interval',
         name: Strings.attributeMaintenanceInterval,
-        type: 'number'
+        type: 'number',
+        convert: 'distance'
     }, {
         key: 'web.liveRouteLength',
         name: Strings.attributeWebLiveRouteLength,

--- a/web/app/store/SpeedUnits.js
+++ b/web/app/store/SpeedUnits.js
@@ -33,13 +33,13 @@ Ext.define('Traccar.store.SpeedUnits', {
         factor: 1.15078
     }],
 
-    convertValue: function (value, unit) {
+    convertValue: function (value, unit, back) {
         var model;
         if (!unit) {
             unit = 'kn';
         }
         model = this.findRecord('key', unit);
-        return value * model.get('factor');
+        return back ? value / model.get('factor') : value * model.get('factor');
     },
 
     formatValue: function (value, unit) {

--- a/web/app/view/CustomNumberField.js
+++ b/web/app/view/CustomNumberField.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('Traccar.view.CustomNumberField', {
+    extend: 'Ext.form.field.Number',
+    xtype: 'customNumberField',
+
+    beforeEl: '<div style="width:100%;display:inline-table;">',
+    unitEl: '<div style="display:table-cell;padding-left:10px;vertical-align:middle;">',
+
+    constructor: function (config) {
+        var unit;
+        if (config.convert === 'speed') {
+            unit = Traccar.app.getPreference('speedUnit', 'kn');
+            config.beforeSubTpl = this.beforeEl;
+            config.afterSubTpl = this.unitEl + Ext.getStore('SpeedUnits').findRecord('key', unit).get('name') + '</div></div>';
+            config.rawToValue = function (rawValue) {
+                return Ext.getStore('SpeedUnits').convertValue(rawValue, Traccar.app.getPreference('speedUnit', 'kn'), true);
+            };
+            config.valueToRaw = function (value) {
+                return Ext.getStore('SpeedUnits').convertValue(value, Traccar.app.getPreference('speedUnit', 'kn'));
+            };
+        } else if (config.convert === 'distance') {
+            config.beforeSubTpl = this.beforeEl;
+            unit = Traccar.app.getPreference('distanceUnit', 'km');
+            config.afterSubTpl =  this.unitEl + Ext.getStore('DistanceUnits').findRecord('key', unit).get('name') + '</div></div>';
+            config.rawToValue = function (rawValue) {
+                return Ext.getStore('DistanceUnits').convertValue(rawValue, Traccar.app.getPreference('distanceUnit', 'km'), true);
+            };
+            config.valueToRaw = function (value) {
+                return Ext.getStore('DistanceUnits').convertValue(value, Traccar.app.getPreference('distanceUnit', 'km'));
+            };
+        }
+        this.callParent(arguments);
+    }
+});

--- a/web/app/view/dialog/Attribute.js
+++ b/web/app/view/dialog/Attribute.js
@@ -20,7 +20,8 @@ Ext.define('Traccar.view.dialog.Attribute', {
 
     requires: [
         'Traccar.view.dialog.AttributeController',
-        'Traccar.view.ColorPicker'
+        'Traccar.view.ColorPicker',
+        'Traccar.view.CustomNumberField'
     ],
 
     controller: 'attribute',

--- a/web/app/view/dialog/AttributeController.js
+++ b/web/app/view/dialog/AttributeController.js
@@ -59,12 +59,13 @@ Ext.define('Traccar.view.dialog.AttributeController', {
             type = attribute.get('type');
             config = Ext.clone(this.defaultFieldConfig);
             if (type === 'number') {
-                config.xtype = 'numberfield';
+                config.xtype = 'customNumberField';
                 if (attribute.get('allowDecimals') !== undefined) {
                     config.allowDecimals = attribute.get('allowDecimals');
                 } else {
                     config.allowDecimals = true;
                 }
+                config.convert = attribute.get('convert');
                 config.maxValue = attribute.get('maxValue');
                 config.minValue = attribute.get('minValue');
             } else if (type === 'boolean') {
@@ -76,7 +77,7 @@ Ext.define('Traccar.view.dialog.AttributeController', {
             } else {
                 config.xtype = 'textfield';
             }
-            if (valueField.getXType() !== config.xtype) {
+            if (valueField.getXType() !== config.xtype || valueField.convert !== config.convert) {
                 this.getView().down('form').insert(this.getView().down('form').items.indexOf(valueField), config);
                 this.getView().down('form').remove(valueField);
             } else if (config.xtype === 'numberfield') {

--- a/web/app/view/edit/Attributes.js
+++ b/web/app/view/edit/Attributes.js
@@ -61,9 +61,6 @@ Ext.define('Traccar.view.edit.Attributes', {
                     return Ext.getStore('SpeedUnits').formatValue(value, Traccar.app.getPreference('speedUnit', 'kn'));
                 } else if (attribute && attribute.get('convert') === 'distance') {
                     return Ext.getStore('DistanceUnits').formatValue(value, Traccar.app.getPreference('distanceUnit', 'km'));
-                } else if (attribute && attribute.get('type') === 'color') {
-                    metaData.tdStyle = 'background-color:' + value;
-                    return value;
                 } else {
                     return value;
                 }

--- a/web/app/view/edit/Attributes.js
+++ b/web/app/view/edit/Attributes.js
@@ -43,15 +43,31 @@ Ext.define('Traccar.view.edit.Attributes', {
             text: Strings.sharedName,
             dataIndex: 'name',
             renderer: function (value, metaData) {
-                var result;
+                var attribute;
                 if (this.attributesStore) {
-                    result = Ext.getStore(this.attributesStore).getById(value);
+                    attribute = Ext.getStore(this.attributesStore).getById(value);
                 }
-                return result && result.get('name') ? result.get('name') : value;
+                return attribute && attribute.get('name') ? attribute.get('name') : value;
             }
         }, {
             text: Strings.stateValue,
-            dataIndex: 'value'
+            dataIndex: 'value',
+            renderer: function (value, metaData, record) {
+                var attribute;
+                if (this.attributesStore) {
+                    attribute = Ext.getStore(this.attributesStore).getById(record.get('name'));
+                }
+                if (attribute && attribute.get('convert') === 'speed') {
+                    return Ext.getStore('SpeedUnits').formatValue(value, Traccar.app.getPreference('speedUnit', 'kn'));
+                } else if (attribute && attribute.get('convert') === 'distance') {
+                    return Ext.getStore('DistanceUnits').formatValue(value, Traccar.app.getPreference('distanceUnit', 'km'));
+                } else if (attribute && attribute.get('type') === 'color') {
+                    metaData.tdStyle = 'background-color:' + value;
+                    return value;
+                } else {
+                    return value;
+                }
+            }
         }]
     }
 });


### PR DESCRIPTION
Implemented speed and distance conversion for known attributes
I decided to invent `CustomNumberField` to show units just after the filed
![image](https://cloud.githubusercontent.com/assets/5688080/25173160/9010005e-250c-11e7-970d-972399554657.png)
Unfortunately, if I put bare unit in `afterSubTpl` it is placed under input field. I made a trick with `inline-table`
Code looks not very clean, but result is good and work in all 3 browsers.
![image](https://cloud.githubusercontent.com/assets/5688080/25173399/5f7e618c-250d-11e7-846d-1a4d27b37f5d.png)

Also formatted attributes in grid. Color at the same time.

![image](https://cloud.githubusercontent.com/assets/5688080/25173538/ef3e6718-250d-11e7-82e1-89949102ba3d.png)


 
