### PR TITLE
Revert distance as key for getFormatter

### DIFF
--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -96,7 +96,7 @@ Ext.define('Traccar.AttributeFormatter', {
             return this.speedFormatter;
         } else if (key === 'course') {
             return this.courseFormatter;
-        } else if (key === 'accuracy') {
+        } else if (key === 'distance' || key === 'accuracy') {
             return this.distanceFormatter;
         } else if (key === 'hours') {
             return this.hoursFormatter;


### PR DESCRIPTION
Reverted it, because it is used in reports https://github.com/tananaev/traccar-web/blob/master/web/app/view/ReportController.js#L453
