### PR TITLE
Column filters to most windows

### DIFF
--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -62,6 +62,18 @@ Ext.define('Traccar.AttributeFormatter', {
         return Ext.getStore('Devices').getById(value).get('name');
     },
 
+    groupIdFormatter: function (value) {
+        var group;
+        if (value !== 0) {
+            if (Ext.getStore('AllGroups').getTotalCount() === 0) {
+                group = Ext.getStore('Groups').getById(value);
+            } else {
+                group = Ext.getStore('AllGroups').getById(value);
+            }
+            return group ? group.get('name') : value;
+        }
+    },
+
     lastUpdateFormatter: function (value) {
         var seconds, interval;
 
@@ -113,6 +125,8 @@ Ext.define('Traccar.AttributeFormatter', {
             return this.durationFormatter;
         } else if (key === 'deviceId') {
             return this.deviceIdFormatter;
+        } else if (key === 'groupId') {
+            return this.groupIdFormatter;
         } else if (key === 'lastUpdate') {
             return this.lastUpdateFormatter;
         } else {

--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -63,9 +63,13 @@ Ext.define('Traccar.AttributeFormatter', {
     },
 
     groupIdFormatter: function (value) {
-        var group;
+        var group, store;
         if (value !== 0) {
-            group = Ext.getStore(Ext.getStore('AllGroups').getTotalCount() === 0 ? 'Groups' : 'AllGroups').getById(value);
+            store = Ext.getStore('AllGroups');
+            if (store.getTotalCount() === 0) {
+                store = Ext.getStore('Groups');
+            }
+            group = store.getById(value);
             return group ? group.get('name') : value;
         }
     },

--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -65,11 +65,7 @@ Ext.define('Traccar.AttributeFormatter', {
     groupIdFormatter: function (value) {
         var group;
         if (value !== 0) {
-            if (Ext.getStore('AllGroups').getTotalCount() === 0) {
-                group = Ext.getStore('Groups').getById(value);
-            } else {
-                group = Ext.getStore('AllGroups').getById(value);
-            }
+            group = Ext.getStore(Ext.getStore('AllGroups').getTotalCount() === 0 ? 'Groups' : 'AllGroups').getById(value);
             return group ? group.get('name') : value;
         }
     },

--- a/web/app/view/edit/Attributes.js
+++ b/web/app/view/edit/Attributes.js
@@ -20,9 +20,12 @@ Ext.define('Traccar.view.edit.Attributes', {
     xtype: 'attributesView',
 
     requires: [
+        'Ext.grid.filters.Filters',
         'Traccar.view.edit.AttributesController',
         'Traccar.view.edit.Toolbar'
     ],
+
+    plugins: 'gridfilters',
 
     controller: 'attributes',
 
@@ -42,6 +45,7 @@ Ext.define('Traccar.view.edit.Attributes', {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
+            filter: 'string',
             renderer: function (value, metaData) {
                 var attribute;
                 if (this.attributesStore) {

--- a/web/app/view/edit/Calendars.js
+++ b/web/app/view/edit/Calendars.js
@@ -21,9 +21,12 @@ Ext.define('Traccar.view.edit.Calendars', {
     xtype: 'calendarsView',
 
     requires: [
+        'Ext.grid.filters.Filters',
         'Traccar.view.edit.CalendarsController',
         'Traccar.view.edit.Toolbar'
     ],
+
+    plugins: 'gridfilters',
 
     controller: 'calendars',
     store: 'Calendars',
@@ -43,7 +46,8 @@ Ext.define('Traccar.view.edit.Calendars', {
         },
         items: [{
             text: Strings.sharedName,
-            dataIndex: 'name'
+            dataIndex: 'name',
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/edit/ComputedAttributes.js
+++ b/web/app/view/edit/ComputedAttributes.js
@@ -21,9 +21,12 @@ Ext.define('Traccar.view.edit.ComputedAttributes', {
     xtype: 'computedAttributesView',
 
     requires: [
+        'Ext.grid.filters.Filters',
         'Traccar.view.edit.ComputedAttributesController',
         'Traccar.view.edit.Toolbar'
     ],
+
+    plugins: 'gridfilters',
 
     controller: 'computedAttributes',
     store: 'ComputedAttributes',
@@ -43,10 +46,16 @@ Ext.define('Traccar.view.edit.ComputedAttributes', {
         },
         items: [{
             text: Strings.sharedDescription,
-            dataIndex: 'description'
+            dataIndex: 'description',
+            filter: 'string'
         }, {
             text: Strings.sharedAttribute,
             dataIndex: 'attribute',
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'PositionAttributes'
+            },
             renderer: function (value) {
                 return Ext.getStore('PositionAttributes').getAttributeName(value);
             }
@@ -56,6 +65,11 @@ Ext.define('Traccar.view.edit.ComputedAttributes', {
         }, {
             text: Strings.sharedType,
             dataIndex: 'type',
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'AttributeValueTypes'
+            },
             renderer: function (value) {
                 var type = Ext.getStore('AttributeValueTypes').getById(value);
                 if (type) {

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -139,13 +139,7 @@ Ext.define('Traccar.view.edit.Devices', {
                 labelField: 'name',
                 store: 'Groups'
             },
-            renderer: function (value) {
-                var group;
-                if (value !== 0) {
-                    group = Ext.getStore('Groups').getById(value);
-                    return group ? group.get('name') : value;
-                }
-            }
+            renderer: Traccar.AttributeFormatter.getFormatter('groupId')
         }, {
             text: Strings.deviceStatus,
             dataIndex: 'status',

--- a/web/app/view/edit/Geofences.js
+++ b/web/app/view/edit/Geofences.js
@@ -20,9 +20,12 @@ Ext.define('Traccar.view.edit.Geofences', {
     xtype: 'geofencesView',
 
     requires: [
+        'Ext.grid.filters.Filters',
         'Traccar.view.edit.GeofencesController',
         'Traccar.view.edit.Toolbar'
     ],
+
+    plugins: 'gridfilters',
 
     controller: 'geofences',
     store: 'Geofences',
@@ -42,10 +45,12 @@ Ext.define('Traccar.view.edit.Geofences', {
         },
         items: [{
             text: Strings.sharedName,
-            dataIndex: 'name'
+            dataIndex: 'name',
+            filter: 'string'
         }, {
             text: Strings.sharedDescription,
-            dataIndex: 'description'
+            dataIndex: 'description',
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/edit/Groups.js
+++ b/web/app/view/edit/Groups.js
@@ -20,9 +20,13 @@ Ext.define('Traccar.view.edit.Groups', {
     xtype: 'groupsView',
 
     requires: [
+        'Ext.grid.filters.Filters',
+        'Traccar.AttributeFormatter',
         'Traccar.view.edit.GroupsController',
         'Traccar.view.edit.Toolbar'
     ],
+
+    plugins: 'gridfilters',
 
     controller: 'groups',
     store: 'Groups',
@@ -59,7 +63,18 @@ Ext.define('Traccar.view.edit.Groups', {
         },
         items: [{
             text: Strings.sharedName,
-            dataIndex: 'name'
+            dataIndex: 'name',
+            filter: 'string'
+        }, {
+            text: Strings.groupDialog,
+            dataIndex: 'groupId',
+            hidden: true,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'AllGroups'
+            },
+            renderer: Traccar.AttributeFormatter.getFormatter('groupId')
         }]
     }
 });

--- a/web/app/view/edit/Users.js
+++ b/web/app/view/edit/Users.js
@@ -96,30 +96,36 @@ Ext.define('Traccar.view.edit.Users', {
         },
         items: [{
             text: Strings.sharedName,
-            dataIndex: 'name'
+            dataIndex: 'name',
+            filter: 'string'
         }, {
             text: Strings.userEmail,
             dataIndex: 'email',
             filter: 'string'
         }, {
             text: Strings.userAdmin,
-            dataIndex: 'admin'
+            dataIndex: 'admin',
+            filter: 'boolean'
         }, {
             text: Strings.serverReadonly,
             dataIndex: 'readonly',
-            hidden: true
+            hidden: true,
+            filter: 'boolean'
         }, {
             text: Strings.userDeviceReadonly,
             dataIndex: 'deviceReadonly',
-            hidden: true
+            hidden: true,
+            filter: 'boolean'
         }, {
             text: Strings.userDisabled,
-            dataIndex: 'disabled'
+            dataIndex: 'disabled',
+            filter: 'boolean'
         }, {
             text: Strings.userExpirationTime,
             dataIndex: 'expirationTime',
             hidden: true,
-            renderer: Traccar.AttributeFormatter.getFormatter('expirationTime')
+            renderer: Traccar.AttributeFormatter.getFormatter('expirationTime'),
+            filter: 'date'
         }]
     }
 });

--- a/web/app/view/edit/UsersController.js
+++ b/web/app/view/edit/UsersController.js
@@ -67,6 +67,7 @@ Ext.define('Traccar.view.edit.UsersController', {
 
     onDevicesClick: function () {
         var user = this.getView().getSelectionModel().getSelection()[0];
+        Ext.getStore('AllGroups').load();
         Ext.create('Traccar.view.BaseWindow', {
             title: Strings.deviceTitle,
             items: {

--- a/web/app/view/permissions/DeviceAttributes.js
+++ b/web/app/view/permissions/DeviceAttributes.js
@@ -20,17 +20,29 @@ Ext.define('Traccar.view.permissions.DeviceAttributes', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'deviceAttributesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedDescription,
             dataIndex: 'description',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }, {
             text: Strings.sharedAttribute,
             dataIndex: 'attribute',
             flex: 1,
             minWidth: Traccar.Style.columnWidthNormal,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'PositionAttributes'
+            },
             renderer: function (value) {
                 return Ext.getStore('PositionAttributes').getAttributeName(value);
             }

--- a/web/app/view/permissions/DeviceGeofences.js
+++ b/web/app/view/permissions/DeviceGeofences.js
@@ -19,12 +19,19 @@ Ext.define('Traccar.view.permissions.DeviceGeofences', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'deviceGeofencesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/permissions/GroupAttributes.js
+++ b/web/app/view/permissions/GroupAttributes.js
@@ -20,17 +20,27 @@ Ext.define('Traccar.view.permissions.GroupAttributes', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'groupAttributesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
     columns: {
         items: [{
             text: Strings.sharedDescription,
             dataIndex: 'description',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }, {
             text: Strings.sharedAttribute,
             dataIndex: 'attribute',
             flex: 1,
             minWidth: Traccar.Style.columnWidthNormal,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'PositionAttributes'
+            },
             renderer: function (value) {
                 return Ext.getStore('PositionAttributes').getAttributeName(value);
             }

--- a/web/app/view/permissions/GroupGeofences.js
+++ b/web/app/view/permissions/GroupGeofences.js
@@ -19,12 +19,19 @@ Ext.define('Traccar.view.permissions.GroupGeofences', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'groupGeofencesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/permissions/UserAttributes.js
+++ b/web/app/view/permissions/UserAttributes.js
@@ -20,17 +20,29 @@ Ext.define('Traccar.view.permissions.UserAttributes', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'userAttributesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedDescription,
             dataIndex: 'description',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }, {
             text: Strings.sharedAttribute,
             dataIndex: 'attribute',
             flex: 1,
             minWidth: Traccar.Style.columnWidthNormal,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'PositionAttributes'
+            },
             renderer: function (value) {
                 return Ext.getStore('PositionAttributes').getAttributeName(value);
             }

--- a/web/app/view/permissions/UserCalendars.js
+++ b/web/app/view/permissions/UserCalendars.js
@@ -20,12 +20,19 @@ Ext.define('Traccar.view.permissions.UserCalendars', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'userCalendarsView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/permissions/UserDevices.js
+++ b/web/app/view/permissions/UserDevices.js
@@ -19,17 +19,59 @@ Ext.define('Traccar.view.permissions.UserDevices', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'userDevicesView',
 
+    requires: [
+        'Ext.grid.filters.Filters',
+        'Traccar.AttributeFormatter'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }, {
             text: Strings.deviceIdentifier,
             dataIndex: 'uniqueId',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
+        }, {
+            text: Strings.sharedPhone,
+            dataIndex: 'phone',
+            flex: 1,
+            minWidth: Traccar.Style.columnWidthNormal,
+            hidden: true,
+            filter: 'string'
+        }, {
+            text: Strings.deviceModel,
+            dataIndex: 'model',
+            flex: 1,
+            minWidth: Traccar.Style.columnWidthNormal,
+            hidden: true,
+            filter: 'string'
+        }, {
+            text: Strings.deviceContact,
+            dataIndex: 'contact',
+            flex: 1,
+            minWidth: Traccar.Style.columnWidthNormal,
+            hidden: true,
+            filter: 'string'
+        }, {
+            text: Strings.groupDialog,
+            dataIndex: 'groupId',
+            flex: 1,
+            minWidth: Traccar.Style.columnWidthNormal,
+            hidden: true,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'AllGroups'
+            },
+            renderer: Traccar.AttributeFormatter.getFormatter('groupId')
         }]
     }
 });

--- a/web/app/view/permissions/UserGeofences.js
+++ b/web/app/view/permissions/UserGeofences.js
@@ -19,12 +19,19 @@ Ext.define('Traccar.view.permissions.UserGeofences', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'userGeofencesView',
 
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }]
     }
 });

--- a/web/app/view/permissions/UserGroups.js
+++ b/web/app/view/permissions/UserGroups.js
@@ -19,12 +19,32 @@ Ext.define('Traccar.view.permissions.UserGroups', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'userGroupsView',
 
+    requires: [
+        'Ext.grid.filters.Filters',
+        'Traccar.AttributeFormatter'
+    ],
+
+    plugins: 'gridfilters',
+
     columns: {
         items: [{
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
+        }, {
+            text: Strings.groupDialog,
+            dataIndex: 'groupId',
+            flex: 1,
+            minWidth: Traccar.Style.columnWidthNormal,
+            hidden: true,
+            filter: {
+                type: 'list',
+                labelField: 'name',
+                store: 'AllGroups'
+            },
+            renderer: Traccar.AttributeFormatter.getFormatter('groupId')
         }]
     }
 });

--- a/web/app/view/permissions/UserUsers.js
+++ b/web/app/view/permissions/UserUsers.js
@@ -25,7 +25,8 @@ Ext.define('Traccar.view.permissions.UserUsers', {
             text: Strings.sharedName,
             dataIndex: 'name',
             flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal
+            minWidth: Traccar.Style.columnWidthNormal,
+            filter: 'string'
         }]
     }
 });

--- a/web/load.js
+++ b/web/load.js
@@ -122,7 +122,7 @@
 
     extjsVersion = '6.2.0';
     fontAwesomeVersion = '4.7.0';
-    olVersion = '4.0.1';
+    olVersion = '4.2.0';
     proj4jsVersion = '2.4.3';
 
     if (debugMode) {


### PR DESCRIPTION
- Added columns filters to most windows
- Added more columns to `UserDevices` and `UserGroups`
- Changed openlayers version to 4.2.0

Implemented `groupId` formatter, unfortunately we need both stores `Groups` and `AllGroups`, make it as second parameter.
Or I could replace it with other key, like `groupIdAll` for example.