### PR TITLE
Implement zoom map on select

### DIFF
--- a/web/app/store/ServerAttributes.js
+++ b/web/app/store/ServerAttributes.js
@@ -40,5 +40,12 @@ Ext.define('Traccar.store.ServerAttributes', {
         name: Strings.attributeWebLiveRouteLength,
         valueType: 'number',
         allowDecimals: false
+    }, {
+        key: 'web.selectZoom',
+        name: Strings.attributeWebSelectZoom,
+        valueType: 'number',
+        allowDecimals: false,
+        minValue: Traccar.Style.mapDefaultZoom,
+        maxValue: Traccar.Style.mapMaxZoom
     }]
 });

--- a/web/app/store/UserAttributes.js
+++ b/web/app/store/UserAttributes.js
@@ -72,5 +72,12 @@ Ext.define('Traccar.store.UserAttributes', {
         name: Strings.attributeWebLiveRouteLength,
         valueType: 'number',
         allowDecimals: false
+    }, {
+        key: 'web.selectZoom',
+        name: Strings.attributeWebSelectZoom,
+        valueType: 'number',
+        allowDecimals: false,
+        minValue: Traccar.Style.mapDefaultZoom,
+        maxValue: Traccar.Style.mapMaxZoom
     }]
 });

--- a/web/app/view/map/MapMarkerController.js
+++ b/web/app/view/map/MapMarkerController.js
@@ -74,6 +74,7 @@ Ext.define('Traccar.view.map.MapMarkerController', {
         this.accuracyCircles = {};
         this.liveRoutes = {};
         this.liveRouteLength = Traccar.app.getAttributePreference('web.liveRouteLength', 10);
+        this.selectZoom = Traccar.app.getAttributePreference('web.selectZoom', 0);
     },
 
     getAreaStyle: function (label, color) {
@@ -454,6 +455,9 @@ Ext.define('Traccar.view.map.MapMarkerController', {
             marker.changed();
             if (center) {
                 this.getView().getMapView().setCenter(marker.getGeometry().getCoordinates());
+                if (this.selectZoom !== 0 && this.selectZoom > this.getView().getMapView().getZoom()) {
+                    this.getView().getMapView().setZoom(this.selectZoom);
+                }
             }
         }
 

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -74,6 +74,7 @@
     "attributeProcessingCopyAttributes": "Processing: Copy Attributes",
     "attributeColor": "Color",
     "attributeWebLiveRouteLength": "Web: Live Route Length",
+    "attributeWebSelectZoom": "Web: Zoom On Select",
     "attributeMailSmtpHost": "Mail: SMTP Host",
     "attributeMailSmtpPort": "Mail: SMTP Port",
     "attributeMailSmtpStarttlsEnable": "Mail: SMTP STARTTLS Enable",


### PR DESCRIPTION
- Implemented User/Server `web.selectZoom` attribute
- Zoom map view to desired value on marker (device/report) selection if it is more than current zoom.

If it is close enough leave as is, if it is too far zoom to desired value. Rather convenient I think without unneeded jumps.
