### PR TITLE
Implement Geofences column for Devices with filtering

### DIFF
--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -74,6 +74,18 @@ Ext.define('Traccar.AttributeFormatter', {
         }
     },
 
+    geofenceIdFormatter: function (value) {
+        var geofence, store;
+        if (value !== 0) {
+            store = Ext.getStore('AllGeofences');
+            if (store.getTotalCount() === 0) {
+                store = Ext.getStore('Geofences');
+            }
+            geofence = store.getById(value);
+            return geofence ? geofence.get('name') : value;
+        }
+    },
+
     driverUniqueIdFormatter: function (value) {
         var driver, store;
         if (value !== 0) {
@@ -139,6 +151,8 @@ Ext.define('Traccar.AttributeFormatter', {
             return this.deviceIdFormatter;
         } else if (key === 'groupId') {
             return this.groupIdFormatter;
+        } else if (key === 'geofenceId') {
+            return this.geofenceIdFormatter;
         } else if (key === 'lastUpdate') {
             return this.lastUpdateFormatter;
         } else if (key === 'spentFuel') {

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -215,7 +215,8 @@ Ext.define('Traccar.controller.Root', {
             if (entity) {
                 entity.set({
                     status: array[i].status,
-                    lastUpdate: array[i].lastUpdate
+                    lastUpdate: array[i].lastUpdate,
+                    geofenceIds: array[i].geofenceIds
                 }, {
                     dirty: false
                 });

--- a/web/app/view/ArrayListFilter.js
+++ b/web/app/view/ArrayListFilter.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+Ext.define('Traccar.view.ArrayListFilter', {
+    extend: 'Ext.grid.filters.filter.List',
+    alias: 'grid.filter.arraylist',
+
+    type: 'arraylist',
+
+    constructor: function (config) {
+        var me = this;
+        me.callParent([config]);
+        me.filter.setFilterFn(function (item) {
+            var i, property, value;
+            property = item.get(this.getProperty());
+            value = this.getValue();
+            if (Ext.isArray(property)) {
+                for (i = 0; i < property.length; i++) {
+                    if (value.indexOf(property[i]) !== -1) {
+                        return true;
+                    }
+                }
+            } else {
+                if (value.indexOf(property) !== -1) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+});

--- a/web/app/view/ArrayListFilter.js
+++ b/web/app/view/ArrayListFilter.js
@@ -23,9 +23,8 @@ Ext.define('Traccar.view.ArrayListFilter', {
     type: 'arraylist',
 
     constructor: function (config) {
-        var me = this;
-        me.callParent([config]);
-        me.filter.setFilterFn(function (item) {
+        this.callParent([config]);
+        this.filter.setFilterFn(function (item) {
             var i, property, value;
             property = item.get(this.getProperty());
             value = this.getValue();

--- a/web/app/view/ReportController.js
+++ b/web/app/view/ReportController.js
@@ -456,11 +456,7 @@ Ext.define('Traccar.view.ReportController', {
     }, {
         text: Strings.sharedGeofence,
         dataIndex: 'geofenceId',
-        renderer: function (value) {
-            if (value !== 0) {
-                return Ext.getStore('Geofences').getById(value).get('name');
-            }
-        }
+        renderer: Traccar.AttributeFormatter.getFormatter('geofenceId')
     }],
 
     summaryColumns: [{

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -22,7 +22,8 @@ Ext.define('Traccar.view.edit.Devices', {
     requires: [
         'Ext.grid.filters.Filters',
         'Traccar.AttributeFormatter',
-        'Traccar.view.edit.DevicesController'
+        'Traccar.view.edit.DevicesController',
+        'Traccar.view.ArrayListFilter'
     ],
 
     controller: 'devices',
@@ -149,6 +150,24 @@ Ext.define('Traccar.view.edit.Devices', {
             },
             renderer: Traccar.AttributeFormatter.getFormatter('groupId')
         }, {
+            text: Strings.sharedGeofences,
+            dataIndex: 'geofenceIds',
+            hidden: true,
+            filter: {
+                type: 'arraylist',
+                idField: 'id',
+                labelField: 'name',
+                store: 'Geofences'
+            },
+            renderer: function (value) {
+                var i, result = '';
+                for (i = 0; i < value.length; i++) {
+                    result += Traccar.AttributeFormatter.geofenceIdFormatter(value[i]);
+                    result += (i < value.length - 1) ? ', ' : '';
+                }
+                return result;
+            }
+        }, {
             text: Strings.deviceStatus,
             dataIndex: 'status',
             filter: {
@@ -156,7 +175,7 @@ Ext.define('Traccar.view.edit.Devices', {
                 labelField: 'name',
                 store: 'DeviceStatuses'
             },
-            renderer: function (value, metaData) {
+            renderer: function (value) {
                 var status;
                 if (value) {
                     status = Ext.getStore('DeviceStatuses').getById(value);


### PR DESCRIPTION
Sorry for deviation from plan, I just was interested by this topic https://www.traccar.org/forums/topic/track-only-inside-geofences/

Here is implementation of Geofences column with filtering:
![image](https://user-images.githubusercontent.com/5688080/28255582-4381e1ba-6ad2-11e7-9692-9e4ee11348b5.png)

The main problem was that `Ext.grid.filters.filter.List` used `in` operator to check if column value **in** the list. The simplest way was override `filterFn` function to check intersection of two arrays. The `ArrayListFilter` class implemented in universal way and might be used somewhere else.

Geofences are translated to names and rendered with comma.
