### PR TITLE
Minify improvement

### DIFF
--- a/tools/minify.sh
+++ b/tools/minify.sh
@@ -2,13 +2,20 @@
 
 cd $(dirname $0)/../web
 
-SDK="../../../ext-6.2.0"
+# Sencha Variables
+SENCHAROOT="../../.."
+SDK="${SENCHAROOT}/ext-6.2.0"
 
-sencha compile --classpath=app.js,app,$SDK/packages/core/src,$SDK/packages/core/overrides,$SDK/classic/classic/src,$SDK/classic/classic/overrides \
+INPUTFILE="app.js"
+OUTPUTFILE="app.min.js"
+APPDIR="app"
+
+sencha compile --classpath="${INPUTFILE}","${APPDIR}","${SDK}/packages/core/src","${SDK}/packages/core/overrides","${SDK}/classic/classic/src","${SDK}/classic/classic/overrides" \
        exclude -all \
        and \
-       include -recursive -file app.js \
+       include -recursive -file "${INPUTFILE}" \
        and \
        exclude -namespace=Ext \
        and \
-       concatenate -closure app.min.js
+       concatenate -closure "${OUTPUTFILE}"
+

--- a/tools/minify.sh
+++ b/tools/minify.sh
@@ -5,17 +5,35 @@ cd $(dirname $0)/../web
 # Sencha Variables
 SENCHAROOT="../../.."
 SDK="${SENCHAROOT}/ext-6.2.0"
+CORE="${SDK}/packages/core"
+CLASSIC="${SDK}/classic/classic"
 
 INPUTFILE="app.js"
 OUTPUTFILE="app.min.js"
 APPDIR="app"
 
-sencha compile --classpath="${INPUTFILE}","${APPDIR}","${SDK}/packages/core/src","${SDK}/packages/core/overrides","${SDK}/classic/classic/src","${SDK}/classic/classic/overrides" \
-       exclude -all \
-       and \
-       include -recursive -file "${INPUTFILE}" \
-       and \
-       exclude -namespace=Ext \
-       and \
-       concatenate -closure "${OUTPUTFILE}"
+# Assemble CLASSPATH
+CLASSPATH="${INPUTFILE},${APPDIR}" 
+
+for d in "${CORE}" "${CLASSIC}"
+do
+	for e in "src" "overrides"
+	do
+		if [ ! -d "${d}/${e}" ]
+		then
+			echo "${d}/${e}: directory not found" 1>&2
+			exit 2
+		fi
+
+		CLASSPATH="${CLASSPATH},${d}/${e}"
+	done
+done
+
+# Minify
+sencha compile \
+	--classpath="${CLASSPATH}" \
+	exclude -all and \
+	include -recursive -file "${INPUTFILE}" and \
+	exclude -namespace=Ext and \
+	concatenate -closure "${OUTPUTFILE}"
 

--- a/tools/minify.sh
+++ b/tools/minify.sh
@@ -1,19 +1,37 @@
 #!/bin/sh
 
-cd $(dirname $0)/../web
-
 # Sencha Variables
 SENCHAROOT="../../.."
 SDK="${SENCHAROOT}/ext-6.2.0"
 CORE="${SDK}/packages/core"
 CLASSIC="${SDK}/classic/classic"
 
-INPUTFILE="app.js"
-OUTPUTFILE="app.min.js"
-APPDIR="app"
+if [ ${#} -gt 1 ]
+then
+	echo "usage: $(basename ${0}) <traccar-web directory>"
+	exit 1
+fi
+
+if [ ${#} -eq 0 ]
+then
+	# Maintain default behavior where CWD is assumed to be traccar-web/tools.
+	TRACCARWEB="$(dirname $0)/../web"
+else
+	TRACCARWEB="${1}"
+fi
+
+if [ ! -d "${TRACCARWEB}" ]
+then
+	echo "${TRACCARWEB}: directory not found" 1>&2
+	exit 2
+fi
+
+INPUTFILE="${TRACCARWEB}/app.js"
+OUTPUTFILE="${TRACCARWEB}/app.min.js"
+APPDIR="${TRACCARWEB}/app" 
 
 # Assemble CLASSPATH
-CLASSPATH="${INPUTFILE},${APPDIR}" 
+CLASSPATH="${INPUTFILE},${APPDIR}"
 
 for d in "${CORE}" "${CLASSIC}"
 do


### PR DESCRIPTION
In shell scripts, I avoid assuming the current working directory of where a script will be executed.  I have modified **tools/minify.sh** such that it does not need to be executed from within the **traccar-web/tools** directory.  I have modified it such that it takes one argument: the path to the **traccar-web/web** directory.  That said, the default behavior is preserved - i.e., if no argument is given, it works the same.