### PR TITLE
Do not show geofenceId if it is unknown

### DIFF
--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -82,7 +82,7 @@ Ext.define('Traccar.AttributeFormatter', {
                 store = Ext.getStore('Geofences');
             }
             geofence = store.getById(value);
-            return geofence ? geofence.get('name') : value;
+            return geofence ? geofence.get('name') : '';
         }
     },
 

--- a/web/app/view/dialog/SelectDeviceController.js
+++ b/web/app/view/dialog/SelectDeviceController.js
@@ -25,7 +25,7 @@ Ext.define('Traccar.view.dialog.SelectDeviceController', {
         deviceId = this.lookupReference('deviceField').getValue();
         record = this.getView().record.data;
         Ext.Ajax.request({
-            url: 'api/attributes/computed?deviceId=' + deviceId,
+            url: 'api/attributes/computed/test?deviceId=' + deviceId,
             method: 'POST',
             jsonData: Ext.util.JSON.encode(record),
             callback: function (options, success, response) {

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -164,7 +164,9 @@ Ext.define('Traccar.view.edit.Devices', {
                 if (Ext.isArray(value)) {
                     for (i = 0; i < value.length; i++) {
                         name = Traccar.AttributeFormatter.geofenceIdFormatter(value[i]);
-                        result += name ? name + ((i < value.length - 1) ? ', ' : '') : '';
+                        if (name) {
+                            result += name + ((i < value.length - 1) ? ', ' : '');
+                        }
                     }
                 }
                 return result;

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -160,11 +160,11 @@ Ext.define('Traccar.view.edit.Devices', {
                 store: 'Geofences'
             },
             renderer: function (value) {
-                var i, result = '';
+                var i, name, result = '';
                 if (Ext.isArray(value)) {
                     for (i = 0; i < value.length; i++) {
-                        result += Traccar.AttributeFormatter.geofenceIdFormatter(value[i]);
-                        result += (i < value.length - 1) ? ', ' : '';
+                        name = Traccar.AttributeFormatter.geofenceIdFormatter(value[i]);
+                        result += name ? name + ((i < value.length - 1) ? ', ' : '') : '';
                     }
                 }
                 return result;

--- a/web/app/view/map/MapMarkerController.js
+++ b/web/app/view/map/MapMarkerController.js
@@ -495,11 +495,12 @@ Ext.define('Traccar.view.map.MapMarkerController', {
     },
 
     selectEvent: function (position) {
+        var marker;
         this.fireEvent('deselectfeature');
         if (position) {
-            var maker = this.addReportMarker(position);
-            maker.set('event', true);
-            this.selectMarker(maker, true);
+            marker = this.addReportMarker(position);
+            marker.set('event', true);
+            this.selectMarker(marker, true);
         } else if (this.selectedMarker && this.selectedMarker.get('event')) {
             this.selectMarker(null, false);
         }


### PR DESCRIPTION
I was thinking...
Our approach to geofences do not linked to user is simple, we do not send notifications and filter out events related to them.
But `deofencesIds` may contain such geofences. My opinion is that user should not even know about geofences he has no access. I do not think it is worth to implement filtering on server side, but we can hide them on web side.
I've changed renderer to do not show geofence id if it is unknown.

Also adjusted test API path related to https://github.com/tananaev/traccar/pull/3396
And fixed small style issue.