### PR TITLE
Implement attribute to disable reports

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -103,7 +103,7 @@ Ext.define('Traccar.controller.Root', {
     },
 
     loadApp: function () {
-        var attribution, eventId, main, i;
+        var attribution, eventId;
         Ext.getStore('Groups').load();
         Ext.getStore('Drivers').load();
         Ext.getStore('Geofences').load();
@@ -124,15 +124,7 @@ Ext.define('Traccar.controller.Root', {
         if (Traccar.app.isMobile()) {
             Ext.create('widget.mainMobile');
         } else {
-            main = Ext.create('widget.main');
-            if (Traccar.app.getAttributePreference('web.disableReport', false).toString() === 'true') {
-                for (i = 0; i < main.items.length; i++) {
-                    if (main.items.items[i].isXType('reportView')) {
-                        main.items.items[i].hide();
-                        break;
-                    }
-                }
-            }
+            Ext.create('widget.main');
         }
         eventId = Ext.Object.fromQueryString(window.location.search).eventId;
         if (eventId) {

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -103,7 +103,7 @@ Ext.define('Traccar.controller.Root', {
     },
 
     loadApp: function () {
-        var attribution, eventId;
+        var attribution, eventId, main, i;
         Ext.getStore('Groups').load();
         Ext.getStore('Drivers').load();
         Ext.getStore('Geofences').load();
@@ -124,7 +124,15 @@ Ext.define('Traccar.controller.Root', {
         if (Traccar.app.isMobile()) {
             Ext.create('widget.mainMobile');
         } else {
-            Ext.create('widget.main');
+            main = Ext.create('widget.main');
+            if (Traccar.app.getAttributePreference('web.disableReport', false)) {
+                for (i = 0; i < main.items.length; i++) {
+                    if (main.items.items[i].xtype === 'reportView') {
+                        main.items.items[i].hide();
+                        break;
+                    }
+                }
+            }
         }
         eventId = Ext.Object.fromQueryString(window.location.search).eventId;
         if (eventId) {

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -125,9 +125,9 @@ Ext.define('Traccar.controller.Root', {
             Ext.create('widget.mainMobile');
         } else {
             main = Ext.create('widget.main');
-            if (Traccar.app.getAttributePreference('web.disableReport', false)) {
+            if (Traccar.app.getAttributePreference('web.disableReport', false).toString() === 'true') {
                 for (i = 0; i < main.items.length; i++) {
-                    if (main.items.items[i].xtype === 'reportView') {
+                    if (main.items.items[i].isXType('reportView')) {
                         main.items.items[i].hide();
                         break;
                     }

--- a/web/app/store/ServerAttributes.js
+++ b/web/app/store/ServerAttributes.js
@@ -47,5 +47,9 @@ Ext.define('Traccar.store.ServerAttributes', {
         allowDecimals: false,
         minValue: Traccar.Style.mapDefaultZoom,
         maxValue: Traccar.Style.mapMaxZoom
+    }, {
+        key: 'web.disableReport',
+        name: Strings.attributeWebDisableReport,
+        valueType: 'boolean'
     }]
 });

--- a/web/app/store/ServerAttributes.js
+++ b/web/app/store/ServerAttributes.js
@@ -48,8 +48,8 @@ Ext.define('Traccar.store.ServerAttributes', {
         minValue: Traccar.Style.mapDefaultZoom,
         maxValue: Traccar.Style.mapMaxZoom
     }, {
-        key: 'web.disableReport',
-        name: Strings.attributeWebDisableReport,
+        key: 'ui.disableReport',
+        name: Strings.attributeUiDisableReport,
         valueType: 'boolean'
     }]
 });

--- a/web/app/store/UserAttributes.js
+++ b/web/app/store/UserAttributes.js
@@ -79,5 +79,9 @@ Ext.define('Traccar.store.UserAttributes', {
         allowDecimals: false,
         minValue: Traccar.Style.mapDefaultZoom,
         maxValue: Traccar.Style.mapMaxZoom
+    }, {
+        key: 'web.disableReport',
+        name: Strings.attributeWebDisableReport,
+        valueType: 'boolean'
     }]
 });

--- a/web/app/store/UserAttributes.js
+++ b/web/app/store/UserAttributes.js
@@ -80,8 +80,8 @@ Ext.define('Traccar.store.UserAttributes', {
         minValue: Traccar.Style.mapDefaultZoom,
         maxValue: Traccar.Style.mapMaxZoom
     }, {
-        key: 'web.disableReport',
-        name: Strings.attributeWebDisableReport,
+        key: 'ui.disableReport',
+        name: Strings.attributeUiDisableReport,
         valueType: 'boolean'
     }]
 });

--- a/web/app/view/Main.js
+++ b/web/app/view/Main.js
@@ -20,6 +20,7 @@ Ext.define('Traccar.view.Main', {
     alias: 'widget.main',
 
     requires: [
+        'Traccar.view.MainController',
         'Traccar.view.edit.Devices',
         'Traccar.view.State',
         'Traccar.view.Report',
@@ -27,18 +28,7 @@ Ext.define('Traccar.view.Main', {
         'Traccar.view.map.Map'
     ],
 
-    initComponent: function () {
-        var i;
-        if (Traccar.app.getAttributePreference('ui.disableReport', false).toString() === 'true') {
-            for (i = 0; i < this.items.length; i++) {
-                if (this.items[i].xtype === 'reportView') {
-                    this.items[i].hidden = true;
-                    break;
-                }
-            }
-        }
-        this.callParent(arguments);
-    },
+    controller: 'mainController',
 
     layout: 'border',
 
@@ -73,6 +63,7 @@ Ext.define('Traccar.view.Main', {
     }, {
         region: 'south',
         xtype: 'reportView',
+        reference: 'reportView',
         height: Traccar.Style.reportHeight,
         collapsed: true,
         titleCollapse: true,

--- a/web/app/view/Main.js
+++ b/web/app/view/Main.js
@@ -27,6 +27,19 @@ Ext.define('Traccar.view.Main', {
         'Traccar.view.map.Map'
     ],
 
+    initComponent: function () {
+        var i;
+        if (Traccar.app.getAttributePreference('ui.disableReport', false).toString() === 'true') {
+            for (i = 0; i < this.items.length; i++) {
+                if (this.items[i].xtype === 'reportView') {
+                    this.items[i].hidden = true;
+                    break;
+                }
+            }
+        }
+        this.callParent(arguments);
+    },
+
     layout: 'border',
 
     defaults: {

--- a/web/app/view/MainController.js
+++ b/web/app/view/MainController.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('Traccar.view.MainController', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.mainController',
+
+    init: function () {
+        this.lookupReference('reportView').setHidden(
+                Traccar.app.getAttributePreference('ui.disableReport', false).toString() === 'true');
+    }
+});

--- a/web/app/view/map/MapController.js
+++ b/web/app/view/map/MapController.js
@@ -44,7 +44,8 @@ Ext.define('Traccar.view.map.MapController', {
 
     init: function () {
         this.callParent();
-        this.lookupReference('showReportsButton').setVisible(Traccar.app.isMobile());
+        this.lookupReference('showReportsButton').setVisible(Traccar.app.isMobile() &&
+                !Traccar.app.getAttributePreference('web.disableReport', false));
         this.lookupReference('showEventsButton').setVisible(Traccar.app.isMobile());
     },
 

--- a/web/app/view/map/MapController.js
+++ b/web/app/view/map/MapController.js
@@ -45,7 +45,7 @@ Ext.define('Traccar.view.map.MapController', {
     init: function () {
         this.callParent();
         this.lookupReference('showReportsButton').setVisible(Traccar.app.isMobile() &&
-                !Traccar.app.getAttributePreference('web.disableReport', false));
+                !Traccar.app.getAttributePreference('ui.disableReport', false));
         this.lookupReference('showEventsButton').setVisible(Traccar.app.isMobile());
     },
 

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -88,6 +88,7 @@
     "attributeMailSmtpAuth": "Mail: SMTP Auth Enable",
     "attributeMailSmtpUsername": "Mail: SMTP Username",
     "attributeMailSmtpPassword": "Mail: SMTP Password",
+    "attributeWebDisableReport": "Web: Disable Report",
     "errorTitle": "Error",
     "errorGeneral": "Invalid parameters or constraints violation",
     "errorConnection": "Connection error",

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -88,7 +88,7 @@
     "attributeMailSmtpAuth": "Mail: SMTP Auth Enable",
     "attributeMailSmtpUsername": "Mail: SMTP Username",
     "attributeMailSmtpPassword": "Mail: SMTP Password",
-    "attributeWebDisableReport": "Web: Disable Report",
+    "attributeUiDisableReport": "UI: Disable Report",
     "errorTitle": "Error",
     "errorGeneral": "Invalid parameters or constraints violation",
     "errorConnection": "Connection error",


### PR DESCRIPTION
Lets start to implement features to hide some functionality in web-client.

Introduced attribute`web.disableReport` to hide report panel.

This is only feature I would make also respected by server. It will be additional protection for public use case. For example in taxi use case readonly user (customer) should not be able see history of car appointed to him. What do you think?

One comment in code...
