### PR TITLE
Add autocapitalize=none to login email input for mobile browsers

### DIFF
--- a/web/app/view/dialog/Login.js
+++ b/web/app/view/dialog/Login.js
@@ -73,7 +73,7 @@ Ext.define('Traccar.view.dialog.Login', {
                 specialKey: 'onSpecialKey',
                 afterrender: 'onAfterRender'
             },
-            inputAttrTpl: ['autocomplete="on"']
+            inputAttrTpl: ['autocomplete="on" autocapitalize="none"']
         }, {
             xtype: 'textfield',
             name: 'password',

--- a/web/app/view/dialog/Login.js
+++ b/web/app/view/dialog/Login.js
@@ -69,7 +69,6 @@ Ext.define('Traccar.view.dialog.Login', {
             fieldLabel: Strings.userEmail,
             allowBlank: false,
             enableKeyEvents: true,
-            
             listeners: {
                 specialKey: 'onSpecialKey',
                 afterrender: 'onAfterRender'


### PR DESCRIPTION
Added due to mobiles trying to capup the first letter of the email address.

Should the login api for traccar do `email.toLowerCase()` before validation?