### PR TITLE
Optimize calendar load

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
             "Traccar": false,
             "Strings": false,
             "Locale": false,
-            "proj4": false,
-            "Uint8Array": false
+            "proj4": false
         },
         "rules": {
             "strict": "off",

--- a/web/app/view/dialog/CalendarController.js
+++ b/web/app/view/dialog/CalendarController.js
@@ -26,12 +26,12 @@ Ext.define('Traccar.view.dialog.CalendarController', {
             reader = new FileReader();
             reader.onload = function (event) {
                 fileField.up('window').lookupReference('dataField').setValue(
-                    btoa(String.fromCharCode.apply(null, new Uint8Array(event.target.result))));
+                    event.target.result.substr(event.target.result.indexOf(',') + 1));
             };
             reader.onerror = function (event) {
                 Traccar.app.showError(event.target.error);
             };
-            reader.readAsArrayBuffer(fileField.fileInputEl.dom.files[0]);
+            reader.readAsDataURL(fileField.fileInputEl.dom.files[0]);
         }
     }
 });


### PR DESCRIPTION
fix #554 
Used `readAsDataURL` to make `FileReader` convert to base64 itself,  but result looks like
````
data:text/calendar;base64,QkVHSU46...
````
and we need bare base64
Used `substr` to split.