### PR TITLE
Fix duration formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .project
 .settings
+.tern-project
 .DS_Store
 nbproject/
 web/app.min.js

--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -55,7 +55,7 @@ Ext.define('Traccar.AttributeFormatter', {
     durationFormatter: function (value) {
         var hours, minutes;
         hours = Math.floor(value / 3600000);
-        minutes = value >= 60000 ? Math.floor(value % 3600000 / 60000) : Math.round(value / 60000);
+        minutes = Math.floor(value % 3600000 / 60000);
         return hours + ' ' + Strings.sharedHourAbbreviation + ' ' + minutes + ' ' + Strings.sharedMinuteAbbreviation;
     },
 

--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -55,7 +55,7 @@ Ext.define('Traccar.AttributeFormatter', {
     durationFormatter: function (value) {
         var hours, minutes;
         hours = Math.floor(value / 3600000);
-        minutes = Math.round(value % 3600000 / 60000);
+        minutes = value >= 60000 ? Math.floor(value % 3600000 / 60000) : Math.round(value / 60000);
         return hours + ' ' + Strings.sharedHourAbbreviation + ' ' + minutes + ' ' + Strings.sharedMinuteAbbreviation;
     },
 


### PR DESCRIPTION
fix #560 

Just truncating also not very good, because 59 seconds we will get as "0 h 0 m"

Here is result test:
````javascript
Traccar.AttributeFormatter.durationFormatter(7200000)
"2 h 0 m"
Traccar.AttributeFormatter.durationFormatter(7199999)
"1 h 59 m"
Traccar.AttributeFormatter.durationFormatter(60000)
"0 h 1 m"
Traccar.AttributeFormatter.durationFormatter(59000)
"0 h 1 m"
Traccar.AttributeFormatter.durationFormatter(29000)
"0 h 0 m"
````

Hope you don't mind adding one file to `.gitignore`. [Recomended](https://eslint.org/docs/user-guide/integrations) way integrate ESLint to Eclipse is using [Tern](https://github.com/angelozerr/tern.java/wiki/Tern-Linter-ESLint) 