### PR TITLE
Save attributes with correct types

### DIFF
--- a/web/app/model/Attribute.js
+++ b/web/app/model/Attribute.js
@@ -25,8 +25,7 @@ Ext.define('Traccar.model.Attribute', {
         name: 'name',
         type: 'string'
     }, {
-        name: 'value',
-        type: 'string'
+        name: 'value'
     }, {
         name: 'attribute',
         type: 'string'

--- a/web/app/view/Statistics.js
+++ b/web/app/view/Statistics.js
@@ -25,28 +25,31 @@ Ext.define('Traccar.view.Statistics', {
     controller: 'statistics',
     store: 'Statistics',
 
-    tbar: [{
-        xtype: 'tbtext',
-        html: Strings.reportFrom
-    }, {
-        xtype: 'datefield',
-        reference: 'fromDateField',
-        startDay: Traccar.Style.weekStartDay,
-        format: Traccar.Style.dateFormat,
-        value: new Date(new Date().getTime() - 24 * 60 * 60 * 1000)
-    }, '-', {
-        xtype: 'tbtext',
-        html: Strings.reportTo
-    }, {
-        xtype: 'datefield',
-        reference: 'toDateField',
-        startDay: Traccar.Style.weekStartDay,
-        format: Traccar.Style.dateFormat,
-        value: new Date()
-    }, '-', {
-        text: Strings.reportShow,
-        handler: 'onShowClick'
-    }],
+    tbar: {
+        scrollable: true,
+        items: [{
+            xtype: 'tbtext',
+            html: Strings.reportFrom
+        }, {
+            xtype: 'datefield',
+            reference: 'fromDateField',
+            startDay: Traccar.Style.weekStartDay,
+            format: Traccar.Style.dateFormat,
+            value: new Date(new Date().getTime() - 24 * 60 * 60 * 1000)
+        }, '-', {
+            xtype: 'tbtext',
+            html: Strings.reportTo
+        }, {
+            xtype: 'datefield',
+            reference: 'toDateField',
+            startDay: Traccar.Style.weekStartDay,
+            format: Traccar.Style.dateFormat,
+            value: new Date()
+        }, '-', {
+            text: Strings.reportShow,
+            handler: 'onShowClick'
+        }]
+    },
 
     columns: {
         defaults: {

--- a/web/app/view/dialog/Server.js
+++ b/web/app/view/dialog/Server.js
@@ -68,15 +68,13 @@ Ext.define('Traccar.view.dialog.Server', {
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'twelveHourFormat',
-                fieldLabel: Strings.settingsTwelveHourFormat,
-                allowBlank: false
+                fieldLabel: Strings.settingsTwelveHourFormat
             }, {
                 xtype: 'checkboxfield',
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'forceSettings',
-                fieldLabel: Strings.serverForceSettings,
-                allowBlank: false
+                fieldLabel: Strings.serverForceSettings
             }, {
                 xtype: 'combobox',
                 name: 'coordinateFormat',
@@ -96,22 +94,19 @@ Ext.define('Traccar.view.dialog.Server', {
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'registration',
-                fieldLabel: Strings.serverRegistration,
-                allowBlank: false
+                fieldLabel: Strings.serverRegistration
             }, {
                 xtype: 'checkboxfield',
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'readonly',
-                fieldLabel: Strings.serverReadonly,
-                allowBlank: false
+                fieldLabel: Strings.serverReadonly
             }, {
                 xtype: 'checkboxfield',
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'deviceReadonly',
-                fieldLabel: Strings.userDeviceReadonly,
-                allowBlank: false
+                fieldLabel: Strings.userDeviceReadonly
             }]
         }]
     },

--- a/web/app/view/dialog/User.js
+++ b/web/app/view/dialog/User.js
@@ -85,8 +85,7 @@ Ext.define('Traccar.view.dialog.User', {
                 inputValue: true,
                 uncheckedValue: false,
                 name: 'twelveHourFormat',
-                fieldLabel: Strings.settingsTwelveHourFormat,
-                allowBlank: false
+                fieldLabel: Strings.settingsTwelveHourFormat
             }, {
                 xtype: 'combobox',
                 name: 'coordinateFormat',

--- a/web/app/view/edit/Users.js
+++ b/web/app/view/edit/Users.js
@@ -33,6 +33,7 @@ Ext.define('Traccar.view.edit.Users', {
 
     tbar: {
         xtype: 'editToolbar',
+        scrollable: true,
         items: [{
             disabled: true,
             handler: 'onGeofencesClick',


### PR DESCRIPTION
Now attribute type is according to component (numderfield, checkbox, textfield) where it was created.

Also added `scrollable: true` to `Users` and `Statistics` windows, because buttons do not fit in vertical mobile view (720x1280).

And also removed meaningless `allowBlank: false` from checkboxes 