### PR TITLE
Fix reports with missed values

### DIFF
--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -52,7 +52,7 @@ Ext.define('Traccar.controller.Root', {
         if (value !== undefined) {
             return Traccar.AttributeFormatter.getAttributeConverter(this.attributeKey)(value);
         }
-        return null;
+        return value;
     },
 
     onLaunch: function () {


### PR DESCRIPTION
Chart generating brakes if some attributes missed in the set https://www.traccar.org/forums/topic/graphic-report-issue/
as well as route grid (just warning, but...)

ExtJS correctly handle missed values, but they should be `undefined`, not `null`