### PR TITLE
Make keyboard zoom and pan working

### DIFF
--- a/web/app/view/map/BaseMap.js
+++ b/web/app/view/map/BaseMap.js
@@ -175,6 +175,8 @@ Ext.define('Traccar.view.map.BaseMap', {
             view: this.mapView
         });
 
+        this.body.dom.tabIndex = 0;
+
         switch (Traccar.app.getAttributePreference('distanceUnit', 'km')) {
             case 'mi':
                 this.map.addControl(new ol.control.ScaleLine({


### PR DESCRIPTION
fix #584 

Actually it is enabled by default https://openlayers.org/en/latest/apidoc/ol.interaction.KeyboardZoom.html and even working if user click on "i" or "+ -" controls.
The problem is that `div` containing map is not "focusable". This change makes it "focusable"

Now user can click on any point of map and zoom and pan will work.