### PR TITLE
Make cell text "selectable" in all grids

### DIFF
--- a/web/app/view/Events.js
+++ b/web/app/view/Events.js
@@ -17,7 +17,7 @@
  */
 
 Ext.define('Traccar.view.Events', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'eventsView',
 
     requires: [

--- a/web/app/view/GridPanel.js
+++ b/web/app/view/GridPanel.js
@@ -15,24 +15,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+Ext.define('Traccar.view.GridPanel', {
+    extend: 'Ext.grid.Panel',
+    xtype: 'customGridPanel',
 
-Ext.define('Traccar.view.permissions.Drivers', {
-    extend: 'Traccar.view.permissions.Base',
-    xtype: 'linkDriversView',
+    requires: [
+        'Ext.grid.filters.Filters'
+    ],
 
-    columns: {
-        items: [{
-            text: Strings.sharedName,
-            dataIndex: 'name',
-            flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal,
-            filter: 'string'
-        }, {
-            text: Strings.deviceIdentifier,
-            dataIndex: 'uniqueId',
-            flex: 1,
-            minWidth: Traccar.Style.columnWidthNormal,
-            filter: 'string'
-        }]
+    plugins: 'gridfilters',
+
+    viewConfig: {
+        enableTextSelection: true,
+        getRowClass: function () {
+            return this.enableTextSelection ? 'x-selectable' : '';
+        }
     }
 });

--- a/web/app/view/Report.js
+++ b/web/app/view/Report.js
@@ -20,7 +20,8 @@ Ext.define('Traccar.view.Report', {
     xtype: 'reportView',
 
     requires: [
-        'Traccar.view.ReportController'
+        'Traccar.view.ReportController',
+        'Traccar.view.GridPanel'
     ],
 
     controller: 'report',
@@ -70,7 +71,7 @@ Ext.define('Traccar.view.Report', {
     layout: 'card',
 
     items: [{
-        xtype: 'grid',
+        xtype: 'customGridPanel',
         itemId: 'grid',
         listeners: {
             selectionchange: 'onSelectionChange'

--- a/web/app/view/State.js
+++ b/web/app/view/State.js
@@ -16,7 +16,7 @@
  */
 
 Ext.define('Traccar.view.State', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'stateView',
 
     requires: [

--- a/web/app/view/Statistics.js
+++ b/web/app/view/Statistics.js
@@ -15,7 +15,7 @@
  */
 
 Ext.define('Traccar.view.Statistics', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'statisticsView',
 
     requires: [

--- a/web/app/view/edit/Attributes.js
+++ b/web/app/view/edit/Attributes.js
@@ -16,16 +16,13 @@
  */
 
 Ext.define('Traccar.view.edit.Attributes', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'attributesView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.AttributesController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'attributes',
 

--- a/web/app/view/edit/Calendars.js
+++ b/web/app/view/edit/Calendars.js
@@ -17,16 +17,13 @@
  */
 
 Ext.define('Traccar.view.edit.Calendars', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'calendarsView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.CalendarsController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'calendars',
     store: 'Calendars',

--- a/web/app/view/edit/ComputedAttributes.js
+++ b/web/app/view/edit/ComputedAttributes.js
@@ -17,16 +17,13 @@
  */
 
 Ext.define('Traccar.view.edit.ComputedAttributes', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'computedAttributesView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.ComputedAttributesController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'computedAttributes',
     store: 'ComputedAttributes',

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -16,11 +16,10 @@
  */
 
 Ext.define('Traccar.view.edit.Devices', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'devicesView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.AttributeFormatter',
         'Traccar.view.edit.DevicesController',
         'Traccar.view.ArrayListFilter',
@@ -28,8 +27,6 @@ Ext.define('Traccar.view.edit.Devices', {
     ],
 
     controller: 'devices',
-
-    plugins: 'gridfilters',
 
     store: 'VisibleDevices',
 
@@ -82,6 +79,7 @@ Ext.define('Traccar.view.edit.Devices', {
     },
 
     viewConfig: {
+        enableTextSelection: true,
         getRowClass: function (record) {
             var status = record.get('status');
             if (status) {

--- a/web/app/view/edit/Drivers.js
+++ b/web/app/view/edit/Drivers.js
@@ -17,16 +17,13 @@
  */
 
 Ext.define('Traccar.view.edit.Drivers', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'driversView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.DriversController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'drivers',
     store: 'Drivers',

--- a/web/app/view/edit/Geofences.js
+++ b/web/app/view/edit/Geofences.js
@@ -16,16 +16,13 @@
  */
 
 Ext.define('Traccar.view.edit.Geofences', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'geofencesView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.GeofencesController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'geofences',
     store: 'Geofences',

--- a/web/app/view/edit/Groups.js
+++ b/web/app/view/edit/Groups.js
@@ -16,17 +16,14 @@
  */
 
 Ext.define('Traccar.view.edit.Groups', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'groupsView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.AttributeFormatter',
         'Traccar.view.edit.GroupsController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'groups',
     store: 'Groups',

--- a/web/app/view/edit/Notifications.js
+++ b/web/app/view/edit/Notifications.js
@@ -17,16 +17,13 @@
  */
 
 Ext.define('Traccar.view.edit.Notifications', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'notificationsView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.NotificationsController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'notifications',
     store: 'Notifications',

--- a/web/app/view/edit/SavedCommands.js
+++ b/web/app/view/edit/SavedCommands.js
@@ -17,16 +17,13 @@
  */
 
 Ext.define('Traccar.view.edit.SavedCommands', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'savedCommandsView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.SavedCommandsController',
         'Traccar.view.edit.Toolbar'
     ],
-
-    plugins: 'gridfilters',
 
     controller: 'savedCommands',
     store: 'Commands',

--- a/web/app/view/edit/Users.js
+++ b/web/app/view/edit/Users.js
@@ -17,19 +17,16 @@
  */
 
 Ext.define('Traccar.view.edit.Users', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
     xtype: 'usersView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.view.edit.UsersController',
         'Traccar.view.edit.Toolbar'
     ],
 
     controller: 'users',
     store: 'Users',
-
-    plugins: 'gridfilters',
 
     tbar: {
         xtype: 'editToolbar',

--- a/web/app/view/permissions/Base.js
+++ b/web/app/view/permissions/Base.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 Ext.define('Traccar.view.permissions.Base', {
-    extend: 'Ext.grid.Panel',
+    extend: 'Traccar.view.GridPanel',
 
     requires: [
         'Traccar.view.permissions.BaseController'

--- a/web/app/view/permissions/Calendars.js
+++ b/web/app/view/permissions/Calendars.js
@@ -20,12 +20,6 @@ Ext.define('Traccar.view.permissions.Calendars', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'linkCalendarsView',
 
-    requires: [
-        'Ext.grid.filters.Filters'
-    ],
-
-    plugins: 'gridfilters',
-
     columns: {
         items: [{
             text: Strings.sharedName,

--- a/web/app/view/permissions/ComputedAttributes.js
+++ b/web/app/view/permissions/ComputedAttributes.js
@@ -20,12 +20,6 @@ Ext.define('Traccar.view.permissions.ComputedAttributes', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'linkComputedAttributesView',
 
-    requires: [
-        'Ext.grid.filters.Filters'
-    ],
-
-    plugins: 'gridfilters',
-
     columns: {
         items: [{
             text: Strings.sharedDescription,

--- a/web/app/view/permissions/Devices.js
+++ b/web/app/view/permissions/Devices.js
@@ -20,11 +20,8 @@ Ext.define('Traccar.view.permissions.Devices', {
     xtype: 'linkDevicesView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.AttributeFormatter'
     ],
-
-    plugins: 'gridfilters',
 
     columns: {
         items: [{

--- a/web/app/view/permissions/Geofences.js
+++ b/web/app/view/permissions/Geofences.js
@@ -19,12 +19,6 @@ Ext.define('Traccar.view.permissions.Geofences', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'linkGeofencesView',
 
-    requires: [
-        'Ext.grid.filters.Filters'
-    ],
-
-    plugins: 'gridfilters',
-
     columns: {
         items: [{
             text: Strings.sharedName,

--- a/web/app/view/permissions/Groups.js
+++ b/web/app/view/permissions/Groups.js
@@ -20,11 +20,8 @@ Ext.define('Traccar.view.permissions.Groups', {
     xtype: 'linkGroupsView',
 
     requires: [
-        'Ext.grid.filters.Filters',
         'Traccar.AttributeFormatter'
     ],
-
-    plugins: 'gridfilters',
 
     columns: {
         items: [{

--- a/web/app/view/permissions/Notifications.js
+++ b/web/app/view/permissions/Notifications.js
@@ -20,12 +20,6 @@ Ext.define('Traccar.view.permissions.Notifications', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'linkNotificationsView',
 
-    requires: [
-        'Ext.grid.filters.Filters'
-    ],
-
-    plugins: 'gridfilters',
-
     columns: {
         items: [{
             text: Strings.notificationType,

--- a/web/app/view/permissions/SavedCommands.js
+++ b/web/app/view/permissions/SavedCommands.js
@@ -20,12 +20,6 @@ Ext.define('Traccar.view.permissions.SavedCommands', {
     extend: 'Traccar.view.permissions.Base',
     xtype: 'linkSavedCommandsView',
 
-    requires: [
-        'Ext.grid.filters.Filters'
-    ],
-
-    plugins: 'gridfilters',
-
     columns: {
         items: [{
             text: Strings.sharedDescription,


### PR DESCRIPTION
Looks like #513 abandoned...

Implement base Grid Panel class with common configs:
- `enableTextSelection: true`
-  `plugins: 'gridfilters'` - it is used in most grids

Applied workaround for selection in windows https://stackoverflow.com/questions/42760943/workaround-for-bug-extjs-22715-enabletextselection-true-has-no-effect-inside-wi
