### PR TITLE
Enable word wrapping in State panel

### DIFF
--- a/web/app/view/State.js
+++ b/web/app/view/State.js
@@ -59,6 +59,7 @@ Ext.define('Traccar.view.State', {
         }, {
             text: Strings.stateValue,
             dataIndex: 'value',
+            cellWrap: true,
             renderer: function (value, metaData, record) {
                 if (record.get('attribute') === 'alarm') {
                     metaData.tdCls = 'view-color-red';


### PR DESCRIPTION
It is impossible to read long values in State Panel, enabled word wrapping in "Value" column.
fix #607 