### PR TITLE
Update openlayers to 4.6.1

### DIFF
--- a/web/app/view/map/MapMarkerController.js
+++ b/web/app/view/map/MapMarkerController.js
@@ -104,7 +104,7 @@ Ext.define('Traccar.view.map.MapMarkerController', {
         if (label) {
             styleConfig.text = new ol.style.Text({
                 text: label,
-                exceedLength: true,
+                overflow: true,
                 fill: new ol.style.Fill({
                     color: Traccar.Style.mapGeofenceTextColor
                 }),

--- a/web/load.js
+++ b/web/load.js
@@ -145,7 +145,7 @@
 
     extjsVersion = '6.2.0';
     fontAwesomeVersion = '4.7.0';
-    olVersion = '4.5.0';
+    olVersion = '4.6.1';
     proj4jsVersion = '2.4.3';
 
     if (debugMode) {


### PR DESCRIPTION
Updated openlayers to recently released
`exceedLength` was deprecated (so fast) and renamed to `overflow` https://github.com/openlayers/openlayers/releases/tag/v4.6.0