### PR TITLE
Implement custom combobox with clear button

### DIFF
--- a/web/app/Style.js
+++ b/web/app/Style.js
@@ -27,7 +27,6 @@ Ext.define('Traccar.Style', {
     windowHeight: 600,
 
     formFieldWidth: 275,
-    formFieldWithButtonWidth: 170 - 3 - 32,
 
     dateTimeFormat24: 'Y-m-d H:i:s',
     dateTimeFormat12: 'Y-m-d g:i:s a',

--- a/web/app/view/ClearableComboBox.js
+++ b/web/app/view/ClearableComboBox.js
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-Ext.define('Traccar.view.CustomComboBox', {
+Ext.define('Traccar.view.ClearableComboBox', {
     extend: 'Ext.form.field.ComboBox',
-    xtype: 'customComboBox',
+    xtype: 'clearableComboBox',
 
     editable: false,
     triggers: {

--- a/web/app/view/CustomComboBox.js
+++ b/web/app/view/CustomComboBox.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('Traccar.view.CustomComboBox', {
+    extend: 'Ext.form.field.ComboBox',
+    xtype: 'customComboBox',
+
+    editable: false,
+    triggers: {
+        clear: {
+            cls: 'iconCls: x-fa fa-times',
+            handler: function (button) {
+                button.clearValue();
+            }
+        }
+    }
+});

--- a/web/app/view/dialog/Device.js
+++ b/web/app/view/dialog/Device.js
@@ -19,7 +19,7 @@ Ext.define('Traccar.view.dialog.Device', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
-        'Traccar.view.CustomComboBox'
+        'Traccar.view.ClearableComboBox'
     ],
 
     title: Strings.sharedDevice,
@@ -46,7 +46,7 @@ Ext.define('Traccar.view.dialog.Device', {
             collapsible: true,
             collapsed: true,
             items: [{
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'groupId',
                 fieldLabel: Strings.groupParent,
                 store: 'Groups',

--- a/web/app/view/dialog/Device.js
+++ b/web/app/view/dialog/Device.js
@@ -18,6 +18,10 @@
 Ext.define('Traccar.view.dialog.Device', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
+    requires: [
+        'Traccar.view.CustomComboBox'
+    ],
+
     title: Strings.sharedDevice,
 
     items: {
@@ -42,26 +46,13 @@ Ext.define('Traccar.view.dialog.Device', {
             collapsible: true,
             collapsed: true,
             items: [{
-                xtype: 'fieldcontainer',
-                layout: 'hbox',
+                xtype: 'customComboBox',
+                name: 'groupId',
                 fieldLabel: Strings.groupParent,
-                items: [{
-                    xtype: 'combobox',
-                    name: 'groupId',
-                    store: 'Groups',
-                    queryMode: 'local',
-                    displayField: 'name',
-                    valueField: 'id',
-                    width: Traccar.Style.formFieldWithButtonWidth,
-                    editable: false
-                }, {
-                    xtype: 'button',
-                    glyph: 'xf00d@FontAwesome',
-                    margin: '0 0 0 3px',
-                    handler: function (button) {
-                        button.up().down().clearValue();
-                    }
-                }]
+                store: 'Groups',
+                queryMode: 'local',
+                displayField: 'name',
+                valueField: 'id'
             }, {
                 xtype: 'textfield',
                 name: 'phone',

--- a/web/app/view/dialog/Geofence.js
+++ b/web/app/view/dialog/Geofence.js
@@ -19,7 +19,7 @@ Ext.define('Traccar.view.dialog.Geofence', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
-        'Traccar.view.CustomComboBox',
+        'Traccar.view.ClearableComboBox',
         'Traccar.view.dialog.GeofenceController'
     ],
 
@@ -46,7 +46,7 @@ Ext.define('Traccar.view.dialog.Geofence', {
                 name: 'description',
                 fieldLabel: Strings.sharedDescription
             }, {
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 reference: 'calendarCombo',
                 name: 'calendarId',
                 store: 'Calendars',

--- a/web/app/view/dialog/Geofence.js
+++ b/web/app/view/dialog/Geofence.js
@@ -19,6 +19,7 @@ Ext.define('Traccar.view.dialog.Geofence', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
+        'Traccar.view.CustomComboBox',
         'Traccar.view.dialog.GeofenceController'
     ],
 
@@ -45,14 +46,13 @@ Ext.define('Traccar.view.dialog.Geofence', {
                 name: 'description',
                 fieldLabel: Strings.sharedDescription
             }, {
-                xtype: 'combobox',
+                xtype: 'customComboBox',
                 reference: 'calendarCombo',
                 name: 'calendarId',
                 store: 'Calendars',
                 queryMode: 'local',
                 displayField: 'name',
                 valueField: 'id',
-                editable: false,
                 fieldLabel: Strings.sharedCalendar
             }, {
                 xtype: 'hiddenfield',

--- a/web/app/view/dialog/Group.js
+++ b/web/app/view/dialog/Group.js
@@ -19,7 +19,7 @@ Ext.define('Traccar.view.dialog.Group', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
-        'Traccar.view.CustomComboBox'
+        'Traccar.view.ClearableComboBox'
     ],
 
     title: Strings.groupDialog,
@@ -41,7 +41,7 @@ Ext.define('Traccar.view.dialog.Group', {
             collapsible: true,
             collapsed: true,
             items: [{
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'groupId',
                 store: 'Groups',
                 queryMode: 'local',

--- a/web/app/view/dialog/Group.js
+++ b/web/app/view/dialog/Group.js
@@ -18,6 +18,10 @@
 Ext.define('Traccar.view.dialog.Group', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
+    requires: [
+        'Traccar.view.CustomComboBox'
+    ],
+
     title: Strings.groupDialog,
 
     items: {
@@ -37,26 +41,12 @@ Ext.define('Traccar.view.dialog.Group', {
             collapsible: true,
             collapsed: true,
             items: [{
-                xtype: 'fieldcontainer',
-                layout: 'hbox',
-                fieldLabel: Strings.groupParent,
-                items: [{
-                    xtype: 'combobox',
-                    name: 'groupId',
-                    store: 'Groups',
-                    queryMode: 'local',
-                    displayField: 'name',
-                    valueField: 'id',
-                    width: Traccar.Style.formFieldWithButtonWidth,
-                    editable: false
-                }, {
-                    xtype: 'button',
-                    glyph: 'xf00d@FontAwesome',
-                    margin: '0 0 0 3px',
-                    handler: function (button) {
-                        button.up().down().clearValue();
-                    }
-                }]
+                xtype: 'customComboBox',
+                name: 'groupId',
+                store: 'Groups',
+                queryMode: 'local',
+                displayField: 'name',
+                valueField: 'id'
             }]
         }]
     }

--- a/web/app/view/dialog/Server.js
+++ b/web/app/view/dialog/Server.js
@@ -19,7 +19,7 @@ Ext.define('Traccar.view.dialog.Server', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
-        'Traccar.view.CustomComboBox',
+        'Traccar.view.ClearableComboBox',
         'Traccar.view.dialog.MapPickerController'
     ],
 
@@ -32,7 +32,7 @@ Ext.define('Traccar.view.dialog.Server', {
             xtype: 'fieldset',
             title: Strings.sharedPreferences,
             items: [{
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'map',
                 fieldLabel: Strings.mapLayer,
                 store: 'MapTypes',
@@ -76,7 +76,7 @@ Ext.define('Traccar.view.dialog.Server', {
                 name: 'forceSettings',
                 fieldLabel: Strings.serverForceSettings
             }, {
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'coordinateFormat',
                 fieldLabel: Strings.settingsCoordinateFormat,
                 store: 'CoordinateFormats',

--- a/web/app/view/dialog/Server.js
+++ b/web/app/view/dialog/Server.js
@@ -19,6 +19,7 @@ Ext.define('Traccar.view.dialog.Server', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
+        'Traccar.view.CustomComboBox',
         'Traccar.view.dialog.MapPickerController'
     ],
 
@@ -31,13 +32,12 @@ Ext.define('Traccar.view.dialog.Server', {
             xtype: 'fieldset',
             title: Strings.sharedPreferences,
             items: [{
-                xtype: 'combobox',
+                xtype: 'customComboBox',
                 name: 'map',
                 fieldLabel: Strings.mapLayer,
                 store: 'MapTypes',
                 displayField: 'name',
-                valueField: 'key',
-                editable: false
+                valueField: 'key'
             }, {
                 xtype: 'textfield',
                 name: 'bingKey',
@@ -76,13 +76,12 @@ Ext.define('Traccar.view.dialog.Server', {
                 name: 'forceSettings',
                 fieldLabel: Strings.serverForceSettings
             }, {
-                xtype: 'combobox',
+                xtype: 'customComboBox',
                 name: 'coordinateFormat',
                 fieldLabel: Strings.settingsCoordinateFormat,
                 store: 'CoordinateFormats',
                 displayField: 'name',
-                valueField: 'key',
-                editable: false
+                valueField: 'key'
             }]
         }, {
             xtype: 'fieldset',

--- a/web/app/view/dialog/User.js
+++ b/web/app/view/dialog/User.js
@@ -19,7 +19,7 @@ Ext.define('Traccar.view.dialog.User', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
-        'Traccar.view.CustomComboBox',
+        'Traccar.view.ClearableComboBox',
         'Traccar.view.dialog.UserController'
     ],
 
@@ -57,7 +57,7 @@ Ext.define('Traccar.view.dialog.User', {
                 name: 'phone',
                 fieldLabel: Strings.sharedPhone
             }, {
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'map',
                 fieldLabel: Strings.mapLayer,
                 store: 'MapTypes',
@@ -87,7 +87,7 @@ Ext.define('Traccar.view.dialog.User', {
                 name: 'twelveHourFormat',
                 fieldLabel: Strings.settingsTwelveHourFormat
             }, {
-                xtype: 'customComboBox',
+                xtype: 'clearableComboBox',
                 name: 'coordinateFormat',
                 fieldLabel: Strings.settingsCoordinateFormat,
                 store: 'CoordinateFormats',

--- a/web/app/view/dialog/User.js
+++ b/web/app/view/dialog/User.js
@@ -19,6 +19,7 @@ Ext.define('Traccar.view.dialog.User', {
     extend: 'Traccar.view.dialog.BaseEdit',
 
     requires: [
+        'Traccar.view.CustomComboBox',
         'Traccar.view.dialog.UserController'
     ],
 
@@ -56,13 +57,12 @@ Ext.define('Traccar.view.dialog.User', {
                 name: 'phone',
                 fieldLabel: Strings.sharedPhone
             }, {
-                xtype: 'combobox',
+                xtype: 'customComboBox',
                 name: 'map',
                 fieldLabel: Strings.mapLayer,
                 store: 'MapTypes',
                 displayField: 'name',
-                valueField: 'key',
-                editable: false
+                valueField: 'key'
             }, {
                 xtype: 'numberfield',
                 reference: 'latitude',
@@ -87,13 +87,12 @@ Ext.define('Traccar.view.dialog.User', {
                 name: 'twelveHourFormat',
                 fieldLabel: Strings.settingsTwelveHourFormat
             }, {
-                xtype: 'combobox',
+                xtype: 'customComboBox',
                 name: 'coordinateFormat',
                 fieldLabel: Strings.settingsCoordinateFormat,
                 store: 'CoordinateFormats',
                 displayField: 'name',
-                valueField: 'key',
-                editable: false
+                valueField: 'key'
             }]
         }, {
             xtype: 'fieldset',


### PR DESCRIPTION
Re-implemented changes from https://github.com/tananaev/traccar-web/commit/aff5895a438c29ca3f16a5d2e19bcb81bce08529 with help of triggers

Also added clear button to map layer, coordinates format and geofence calendar fields.

![image](https://user-images.githubusercontent.com/5688080/34143016-47067aae-e4ac-11e7-8bed-42d81a300420.png)

Not sure about position, it is possible to move icon before arrow
![image](https://user-images.githubusercontent.com/5688080/34143023-5ff68f86-e4ac-11e7-9507-a0727a1095b0.png)
