### PR TITLE
Implement POI layer

### DIFF
--- a/web/app/model/Server.js
+++ b/web/app/model/Server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,6 +60,9 @@ Ext.define('Traccar.model.Server', {
         type: 'boolean'
     }, {
         name: 'coordinateFormat',
+        type: 'string'
+    }, {
+        name: 'poiLayer',
         type: 'string'
     }, {
         name: 'attributes'

--- a/web/app/model/User.js
+++ b/web/app/model/User.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -80,6 +80,9 @@ Ext.define('Traccar.model.User', {
     }, {
         name: 'limitCommands',
         type: 'boolean'
+    }, {
+        name: 'poiLayer',
+        type: 'string'
     }, {
         name: 'token',
         type: 'string'

--- a/web/app/view/dialog/Server.js
+++ b/web/app/view/dialog/Server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,6 +82,10 @@ Ext.define('Traccar.view.dialog.Server', {
                 store: 'CoordinateFormats',
                 displayField: 'name',
                 valueField: 'key'
+            }, {
+                xtype: 'textfield',
+                name: 'poiLayer',
+                fieldLabel: Strings.mapPoiLayer
             }]
         }, {
             xtype: 'fieldset',

--- a/web/app/view/dialog/User.js
+++ b/web/app/view/dialog/User.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -93,6 +93,10 @@ Ext.define('Traccar.view.dialog.User', {
                 store: 'CoordinateFormats',
                 displayField: 'name',
                 valueField: 'key'
+            }, {
+                xtype: 'textfield',
+                name: 'poiLayer',
+                fieldLabel: Strings.mapPoiLayer
             }]
         }, {
             xtype: 'fieldset',

--- a/web/app/view/map/BaseMap.js
+++ b/web/app/view/map/BaseMap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ Ext.define('Traccar.view.map.BaseMap', {
     },
 
     initMap: function () {
-        var server, layer, type, bingKey, lat, lon, zoom, maxZoom, target;
+        var server, layer, type, bingKey, lat, lon, zoom, maxZoom, target, poiLayer;
 
         server = Traccar.app.getServer();
 
@@ -152,6 +152,17 @@ Ext.define('Traccar.view.map.BaseMap', {
             layers: [layer],
             view: this.mapView
         });
+
+        poiLayer = Traccar.app.getPreference('poiLayer', null);
+
+        if (poiLayer) {
+            this.map.addLayer(new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    url: poiLayer,
+                    format: new ol.format.KML()
+                })
+            }));
+        }
 
         this.body.dom.tabIndex = 0;
 

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -240,6 +240,7 @@
     "mapShapeCircle": "Circle",
     "mapShapePolyline": "Polyline",
     "mapLiveRoutes": "Live Routes",
+    "mapPoiLayer": "POI Layer",
     "stateTitle": "State",
     "stateName": "Attribute",
     "stateValue": "Value",


### PR DESCRIPTION
Implemented POI layer, it can be used for adding static objects on the map or any other features supported by KML and openlayers.

![image](https://user-images.githubusercontent.com/5688080/35034430-f992de2a-fb8f-11e7-98db-8e6d43453887.png)

![image](https://user-images.githubusercontent.com/5688080/35034452-0d7b00ac-fb90-11e7-9b6c-6b394a155bcf.png)

Here green line is KML LineString.

I would share this example `test.kml` but not sure where to put it. (appropriate folder)

fix #173 