### PR TITLE
Add Decoder Timezone attribute

### DIFF
--- a/web/app/store/DeviceAttributes.js
+++ b/web/app/store/DeviceAttributes.js
@@ -31,5 +31,10 @@ Ext.define('Traccar.store.DeviceAttributes', {
         key: 'processing.copyAttributes',
         name: Strings.attributeProcessingCopyAttributes,
         valueType: 'string'
+    }, {
+        key: 'decoder.timezone',
+        name: Strings.sharedTimezone,
+        valueType: 'string',
+        dataType: 'timezone'
     }]
 });

--- a/web/app/store/GroupAttributes.js
+++ b/web/app/store/GroupAttributes.js
@@ -23,5 +23,10 @@ Ext.define('Traccar.store.GroupAttributes', {
         key: 'processing.copyAttributes',
         name: Strings.attributeProcessingCopyAttributes,
         valueType: 'string'
+    }, {
+        key: 'decoder.timezone',
+        name: Strings.sharedTimezone,
+        valueType: 'string',
+        dataType: 'timezone'
     }]
 });


### PR DESCRIPTION
Added Decoder Timezone attribute to device and group.
Used `sharedTimezone` string, do not think we need separate.